### PR TITLE
CVSB-4082 fix signatures not getting added to certs.

### DIFF
--- a/src/providers/signature/signature.service.spec.ts
+++ b/src/providers/signature/signature.service.spec.ts
@@ -60,9 +60,10 @@ describe('SignatureService', () => {
   });
 
   it('should check if saveSignature haveBeenCalled', () => {
-    signatureService.signatureString = 'ojghhghasghwogjwrgohjrgohergoueqhgpieqhgeqpughouh234rh34oruh43pu3h45u4h5pio34h53uh53p4o5h34potuh3outh3poituh3tpu3htpiou3htp';
+    signatureService.signatureString = '22charsofgibberish////dGVzdA==';
     signatureService.saveSignature();
     expect(httpService.saveSignature).toHaveBeenCalled();
+    expect(httpService.saveSignature).toHaveBeenCalledWith(undefined, 'dGVzdA==')
   });
 
 

--- a/src/providers/signature/signature.service.ts
+++ b/src/providers/signature/signature.service.ts
@@ -26,7 +26,7 @@ export class SignatureService {
   }
 
   saveSignature(): Observable<any> {
-    return this.httpService.saveSignature(this.authService.testerDetails.testerId, this.signatureString.slice(22, this.signatureString.length - 1));
+    return this.httpService.saveSignature(this.authService.testerDetails.testerId, this.signatureString.slice(22, this.signatureString.length));
   }
 
   saveToStorage(): Promise<any> {


### PR DESCRIPTION
fixed and I have added the only test which makes sense for this method. Previously a character was being truncated from the payload from the signature pad. It didn't make a meaningful difference if the payload had 1 or 0 equals signs at the end, but broke if there were two. If the string was the wrong length but had no equals signs, then the decoding algorithms self adjust, but if it's wrong and has an equals sign, then it's deemed "corrupt". The new test makes sure that nothing is truncated, which will ensure the correct amount of equals signs are present, resulting in a valid image string.