### PR TITLE
CVSB-8205 Bugfix roadworthiness certificate reset on defect change

### DIFF
--- a/src/pages/testing/defects/defect-details/defect-details.spec.ts
+++ b/src/pages/testing/defects/defect-details/defect-details.spec.ts
@@ -13,9 +13,15 @@ import { ViewControllerMock } from "../../../../../test-config/ionic-mocks/view-
 import { FirebaseLogsService } from "../../../../providers/firebase-logs/firebase-logs.service";
 import { FirebaseLogsServiceMock } from "../../../../../test-config/services-mocks/firebaseLogsService.mock";
 import { By } from "@angular/platform-browser";
-import { TEST_TYPE_RESULTS, DEFICIENCY_CATEGORY, FIREBASE_DEFECTS, APP_STRINGS } from "../../../../app/app.enums";
+import {
+  TEST_TYPE_RESULTS,
+  DEFICIENCY_CATEGORY,
+  FIREBASE_DEFECTS,
+  APP_STRINGS,
+  TEST_TYPES_IDS
+} from '../../../../app/app.enums';
 import { NavControllerMock } from "../../../../../test-config/ionic-mocks/nav-controller.mock";
-import { TestService } from "../../../../providers/test/test.service";
+import {DefectDetailsDataMock} from '../../../../assets/data-mocks/defect-details-data.mock';
 
 describe('Component: DefectDetailsPage', () => {
   let comp: DefectDetailsPage;
@@ -283,7 +289,7 @@ describe('Component: DefectDetailsPage', () => {
     expect(comp.showProhibitionAlert).toHaveBeenCalledWith(APP_STRINGS.PROHIBITION_MSG_CONFIRM);
   });
 
-  it('should set the PRS state on a test having a dangerous defect which has been rectivied on site', () => {
+  it('should set the PRS state on a test having a dangerous defect which has been rectified on site', () => {
     expect(vehicleTest.defects.length).toBe(2);
     vehicleTest.defects[0].deficiencyCategory = DEFICIENCY_CATEGORY.DANGEROUS;
     vehicleTest.defects.map(defect => {
@@ -292,4 +298,50 @@ describe('Component: DefectDetailsPage', () => {
     let testResult: (string | TEST_TYPE_RESULTS) = testTypeService.setTestResult(comp.vehicleTest, true);
     expect(testResult).toBe(TEST_TYPE_RESULTS.PRS);
   });
+
+  it('it should reset the certificate number on a roadworthiness test if the defect to add is critical', () => {
+    comp.fromTestReview = true;
+
+    comp.vehicleTest = TestTypeDataModelMock.TestTypeData;
+    comp.vehicleTest.testTypeId = TEST_TYPES_IDS._62;
+    comp.vehicleTest.certificateNumber = 'TESTCERTIFICATE';
+
+    comp.defect = DefectDetailsDataMock.DefectData;
+    comp.defect.prs = false;
+    comp.defect.deficiencyCategory = DEFICIENCY_CATEGORY.MAJOR;
+
+    comp.checkProhibitionStatus();
+    expect(comp.vehicleTest.certificateNumber).toBeNull();
+  });
+
+  it('it should not reset the certificate number on a roadworthiness test if the defect to be added is prs', () => {
+    comp.fromTestReview = true;
+
+    comp.vehicleTest = TestTypeDataModelMock.TestTypeData;
+    comp.vehicleTest.testTypeId = TEST_TYPES_IDS._63;
+    comp.vehicleTest.certificateNumber = 'TESTCERTIFICATE';
+
+    comp.defect = DefectDetailsDataMock.DefectData;
+    comp.defect.prs = true;
+    comp.defect.deficiencyCategory = DEFICIENCY_CATEGORY.DANGEROUS;
+
+    comp.checkProhibitionStatus();
+    expect(comp.vehicleTest.certificateNumber).toBe('TESTCERTIFICATE');
+  });
+
+  it('it should not reset the certificate number on a roadworthiness test if the defect to be added is minor', () => {
+    comp.fromTestReview = true;
+
+    comp.vehicleTest = TestTypeDataModelMock.TestTypeData;
+    comp.vehicleTest.testTypeId = TEST_TYPES_IDS._91;
+    comp.vehicleTest.certificateNumber = 'TESTCERTIFICATE';
+
+    comp.defect = DefectDetailsDataMock.DefectData;
+    comp.defect.prs = false;
+    comp.defect.deficiencyCategory = DEFICIENCY_CATEGORY.MINOR;
+
+    comp.checkProhibitionStatus();
+    expect(comp.vehicleTest.certificateNumber).toBe('TESTCERTIFICATE');
+  });
+
 });

--- a/src/pages/testing/defects/defect-details/defect-details.ts
+++ b/src/pages/testing/defects/defect-details/defect-details.ts
@@ -8,9 +8,10 @@ import {
 import { DefectsService } from "../../../../providers/defects/defects.service";
 import { TestTypeModel } from "../../../../models/tests/test-type.model";
 import { TestTypeService } from "../../../../providers/test-type/test-type.service";
-import { APP_STRINGS, DEFICIENCY_CATEGORY, FIREBASE_DEFECTS } from "../../../../app/app.enums";
+import {APP_STRINGS, DEFICIENCY_CATEGORY, FIREBASE_DEFECTS, TEST_TYPE_RESULTS} from '../../../../app/app.enums';
 import { FirebaseLogsService } from '../../../../providers/firebase-logs/firebase-logs.service';
 import { ProhibitionClearanceTestTypesData } from "../../../../assets/app-data/test-types-data/prohibition-clearance-test-types.data";
+import {TestTypesFieldsMetadata} from '../../../../assets/app-data/test-types-data/test-types-fields.metadata';
 
 @IonicPage()
 @Component({
@@ -69,6 +70,14 @@ export class DefectDetailsPage implements OnInit {
     }
   }
 
+  /**
+   * Logic on how to go back to complete-test (Test type details) page and add the current defect.
+   * This is when you press Done on defect-details page (Defect details)(when adding a new defect OR when changing an existing defect)
+   * Note: you cannot close complete-test page without saving it so it's ok to add the defect to the test here.
+   *
+   * This adds a defect only is it's first time add defect.
+   * If the "Done" button is pressed on a changed defect, testTypeService.addDefect will not be called
+   */
   addDefect(): void {
     if (!this.fromTestReview) {
       let views = this.navCtrl.getViews();
@@ -82,7 +91,17 @@ export class DefectDetailsPage implements OnInit {
       if (!this.isEdit) this.testTypeService.addDefect(this.vehicleTest, this.defect);
       this.navCtrl.popToRoot();
     }
+
+    if (this.getTestTypeDetailsFromFieldsMetadata(this.vehicleTest).hasRoadworthinessCertificate &&
+      this.testTypeService.setTestResult(this.vehicleTest, this.getTestTypeDetailsFromFieldsMetadata(this.vehicleTest).hasDefects) === TEST_TYPE_RESULTS.FAIL) {
+      this.vehicleTest.certificateNumber = null;
+    }
+
     if (this.notesChanged) this.logFirebaseNotesChanged();
+  }
+
+  private getTestTypeDetailsFromFieldsMetadata(testTypeModel: TestTypeModel) {
+    return TestTypesFieldsMetadata.FieldsMetadata.find((fieldsMetadata) => testTypeModel.testTypeId === fieldsMetadata.testTypeId);
   }
 
   checkForLocation(location: {}): boolean {

--- a/src/providers/test-type/test-type.service.spec.ts
+++ b/src/providers/test-type/test-type.service.spec.ts
@@ -9,10 +9,9 @@ import { TestTypesReferenceDataMock } from "../../assets/data-mocks/reference-da
 import { CommonFunctionsService } from "../utils/common-functions";
 import { TestTypeModel } from "../../models/tests/test-type.model";
 import { TestTypeDataModelMock } from "../../assets/data-mocks/data-model/test-type-data-model.mock";
-import { TEST_TYPE_RESULTS, FIREBASE_DEFECTS, VEHICLE_TYPE, TEST_TYPES_IDS, DEFICIENCY_CATEGORY } from "../../app/app.enums";
+import { TEST_TYPE_RESULTS, VEHICLE_TYPE } from "../../app/app.enums";
 import { FirebaseLogsServiceMock } from "../../../test-config/services-mocks/firebaseLogsService.mock";
 import { FirebaseLogsService } from "../firebase-logs/firebase-logs.service";
-import { Firebase } from "@ionic-native/firebase";
 
 describe('Provider: TestTypeService', () => {
   let testTypeService: TestTypeService;
@@ -83,45 +82,6 @@ describe('Provider: TestTypeService', () => {
     spyOn(firebaseLogsService, 'logEvent').and.returnValue(Promise.resolve(true));
     testTypeService.addDefect(testType, DEFECT);
     expect(firebaseLogsService.logEvent).toHaveBeenCalledTimes(2);
-  });
-
-  it('it should reset the certificate number on a roadworthiness test if the defect to add is critical', () => {
-    let testType: TestTypeModel = TestTypeDataModelMock.TestTypeData;
-    testType.testTypeId = TEST_TYPES_IDS._62;
-    testType.certificateNumber = 'TESTCERTIFICATE';
-
-    let defect = DefectDetailsDataMock.DefectData;
-    defect.prs = false;
-    defect.deficiencyCategory = DEFICIENCY_CATEGORY.MAJOR;
-    testTypeService.addDefect(testType, defect);
-
-    expect(testType.certificateNumber).toBeNull();
-  });
-
-  it('it should not reset the certificate number on a roadworthiness test if the defect to be added is prs', () => {
-    let testType: TestTypeModel = TestTypeDataModelMock.TestTypeData;
-    testType.testTypeId = TEST_TYPES_IDS._63;
-    testType.certificateNumber = 'TESTCERTIFICATE';
-
-    let defect = DefectDetailsDataMock.DefectData;
-    defect.prs = true;
-    defect.deficiencyCategory = DEFICIENCY_CATEGORY.DANGEROUS;
-    testTypeService.addDefect(testType, defect);
-
-    expect(testType.certificateNumber).toBe('TESTCERTIFICATE');
-  });
-
-  it('it should not reset the certificate number on a roadworthiness test if the defect to be added is minor', () => {
-    let testType: TestTypeModel = TestTypeDataModelMock.TestTypeData;
-    testType.testTypeId = TEST_TYPES_IDS._91;
-    testType.certificateNumber = 'TESTCERTIFICATE';
-
-    let defect = DefectDetailsDataMock.DefectData;
-    defect.prs = false;
-    defect.deficiencyCategory = DEFICIENCY_CATEGORY.MINOR;
-    testTypeService.addDefect(testType, defect);
-
-    expect(testType.certificateNumber).toBe('TESTCERTIFICATE');
   });
 
   it('should remove a defect from test', () => {

--- a/src/providers/test-type/test-type.service.ts
+++ b/src/providers/test-type/test-type.service.ts
@@ -9,7 +9,6 @@ import { VisitService } from "../visit/visit.service";
 import { TestTypesReferenceDataModel } from "../../models/reference-data-models/test-types.model";
 import { CommonFunctionsService } from "../utils/common-functions";
 import { FirebaseLogsService } from '../firebase-logs/firebase-logs.service';
-import {TestTypesFieldsMetadata} from '../../assets/app-data/test-types-data/test-types-fields.metadata';
 
 @Injectable()
 export class TestTypeService {
@@ -52,16 +51,8 @@ export class TestTypeService {
 
   addDefect(testType: TestTypeModel, defect: DefectDetailsModel) {
     testType.defects.push(defect);
-    if (this.getTestTypeDetailsFromFieldsMetadata(testType).hasRoadworthinessCertificate &&
-      this.setTestResult(testType, this.getTestTypeDetailsFromFieldsMetadata(testType).hasDefects) === TEST_TYPE_RESULTS.FAIL) {
-        testType.certificateNumber = null;
-    }
     this.visitService.updateVisit();
     this.logFirebaseAddDefect(defect.deficiencyRef);
-  }
-
-  private getTestTypeDetailsFromFieldsMetadata(testTypeModel: TestTypeModel) {
-    return TestTypesFieldsMetadata.FieldsMetadata.find((fieldsMetadata) => testTypeModel.testTypeId === fieldsMetadata.testTypeId);
   }
 
   private logFirebaseAddDefect(deficiencyRef: string) {


### PR DESCRIPTION
To reset certificate number when test is updated from the test-review page, I moved the reset logic  from test-type service to the button controller.
This bugfix will be merged and tested on 6426