### PR TITLE
CVSB-7439 Fixed misspelled leverLength field

### DIFF
--- a/src/models/vehicle/tech-record.model.ts
+++ b/src/models/vehicle/tech-record.model.ts
@@ -149,6 +149,6 @@ export interface VehicleClassModel {
 
 export interface AxleBrakePropertiesModel {
   brakeActuator: number;
-  leverLenght: number;
-  springBrakeParking: number;
+  leverLength: number;
+  springBrakeParking: boolean;
 }

--- a/src/pages/testing/vehicle/vehicle-brakes/vehicle-brakes.html
+++ b/src/pages/testing/vehicle/vehicle-brakes/vehicle-brakes.html
@@ -157,7 +157,7 @@
                     <h3>Lever length</h3>
                 </ion-label>
                 <div item-content padding-right>
-                    <p>{{ axle?.brakes?.leverLenght }}</p>
+                    <p>{{ axle?.brakes?.leverLength }}</p>
                 </div>
             </ion-item>
 
@@ -166,7 +166,7 @@
                     <h3>Spring brake parking</h3>
                 </ion-label>
                 <div item-content padding-right>
-                    <p>{{ axle?.brakes?.springBrakeParking ? APP_STRINGS.YES : APP_STRINGS.NO }}</p>
+                    <p>{{ axle?.brakes?.springBrakeParking !== null ? (axle?.brakes?.springBrakeParking | formatBoolean) : '' }}</p>
                 </div>
             </ion-item>
 
@@ -181,7 +181,7 @@
                     <h3>Load sensing valve</h3>
                 </ion-label>
                 <div item-content padding-right>
-                    <p>{{ vehicleData.techRecord?.brakes?.loadSensingValve ? APP_STRINGS.YES : APP_STRINGS.NO }}</p>
+                    <p>{{ vehicleData.techRecord?.brakes?.loadSensingValve | formatBoolean }}</p>
                 </div>
             </ion-item>
 
@@ -190,7 +190,7 @@
                     <h3>Antilock braking system</h3>
                 </ion-label>
                 <div item-content padding-right>
-                    <p>{{ vehicleData.techRecord?.brakes?.antilockBrakingSystem ? APP_STRINGS.YES : APP_STRINGS.NO }}</p>
+                    <p>{{ vehicleData.techRecord?.brakes?.antilockBrakingSystem | formatBoolean }}</p>
                 </div>
             </ion-item>
 

--- a/src/pages/testing/vehicle/vehicle-brakes/vehicle-brakes.ts
+++ b/src/pages/testing/vehicle/vehicle-brakes/vehicle-brakes.ts
@@ -11,7 +11,6 @@ import { APP_STRINGS, VEHICLE_TYPE } from "../../../../app/app.enums";
 })
 export class VehicleBrakesPage {
   VEHICLE_TYPE: typeof VEHICLE_TYPE=VEHICLE_TYPE;
-  APP_STRINGS: typeof APP_STRINGS=APP_STRINGS;
   vehicleData: VehicleModel;
 
   constructor(public navCtrl: NavController,


### PR DESCRIPTION
This branch will be merged and tested in 6426.
I also noticed that springBrakeParking is defined as a number in the app, while it is provided by the backend as a boolean. This commit also fixes that.