### PR TITLE
CVSB-5287 Fix search test station when testStationAddress is null

### DIFF
--- a/src/assets/data-mocks/reference-data-mocks/test-station-data.mock.ts
+++ b/src/assets/data-mocks/reference-data-mocks/test-station-data.mock.ts
@@ -51,6 +51,22 @@ export class TestStationDataMock {
         testStationEmails: [
           "teststationname@dvsa.gov.uk"
         ]
+      }, {
+        testStationId: '124112',
+        testStationName: 'ATF without testStationAddress',
+        testStationPNumber: '124112',
+        testStationContactNumber: '124112',
+        testStationAccessNotes: 'note2',
+        testStationGeneralNotes: 'gNote2',
+        testStationTown: 'town2',
+        testStationAddress: null,
+        testStationPostcode: '2222',
+        testStationLongitude: 5,
+        testStationLatitude: 6,
+        testStationType: 'atf',
+        testStationEmails: [
+          'teststationname@dvsa.gov.uk'
+        ]
       },
     ];
   }

--- a/src/providers/test-station/test-station.service.spec.ts
+++ b/src/providers/test-station/test-station.service.spec.ts
@@ -91,4 +91,11 @@ describe('Provider: TestStationService', () => {
     expect(filteredData.length).toEqual(0);
   });
 
+  it('should filter test stations that have set null as testStationAddress', () => {
+    filter = 'ATF without testStationAddress';
+    let filteredData = testStationService.sortAndSearchTestStation(initialData, filter, PROPERTIES);
+
+    expect(filteredData.length).toEqual(1);
+    expect(filteredData[0][0].testStationName).toEqual(filter);
+  });
 });

--- a/src/providers/test-station/test-station.service.ts
+++ b/src/providers/test-station/test-station.service.ts
@@ -39,7 +39,7 @@ export class TestStationService {
             for (let key in item) {
               let propIndex: number = properties.indexOf(key);
               if (propIndex != -1) {
-                if (item[key].toString().toLowerCase().includes(filter.toLowerCase())) {
+                if (item[key]!==null && item[key].toString().toLowerCase().includes(filter.toLowerCase())) {
                   item.searchProperty = properties[propIndex];
                   return item;
                 }


### PR DESCRIPTION
This is a bug fix to filter test stations when the testStationAddress is null. This bug was not present in dev environment because there are no test stations in the db having this issue.