### PR TITLE
CVSB-9258 Fixed bug populating new tests with data after restart

### DIFF
--- a/src/pages/testing/test-creation/test-cancel/test-cancel.ts
+++ b/src/pages/testing/test-creation/test-cancel/test-cancel.ts
@@ -148,6 +148,7 @@ export class TestCancelPage {
               let activityIndex = this.activityService.activities.map((activity) => activity.endTime).indexOf(testResult.testStartTimestamp);
               if (activityIndex > -1) this.activityService.activities[activityIndex].id = resp.body.id;
               this.activityService.updateActivities();
+              this.visitService.updateVisit();
             },
             (error) => {
               const log: Log = {

--- a/src/pages/testing/test-creation/test-review/test-review.ts
+++ b/src/pages/testing/test-creation/test-review/test-review.ts
@@ -223,6 +223,7 @@ export class TestReviewPage implements OnInit {
               this.latestTest.status = TEST_REPORT_STATUSES.SUBMITTED;
               this.testService.endTestReport(this.latestTest);
               this.submit(this.latestTest);
+              this.visitService.updateVisit();
             }
           }
         ]

--- a/src/pages/testing/test-creation/test-review/test-review.ts
+++ b/src/pages/testing/test-creation/test-review/test-review.ts
@@ -223,7 +223,6 @@ export class TestReviewPage implements OnInit {
               this.latestTest.status = TEST_REPORT_STATUSES.SUBMITTED;
               this.testService.endTestReport(this.latestTest);
               this.submit(this.latestTest);
-              this.visitService.updateVisit();
             }
           }
         ]
@@ -300,6 +299,7 @@ export class TestReviewPage implements OnInit {
               let activityIndex = this.activityService.activities.map((activity) => activity.endTime).indexOf(testResult.testStartTimestamp);
               if (activityIndex > -1) this.activityService.activities[activityIndex].id = resp.body.id;
               this.activityService.updateActivities();
+              this.visitService.updateVisit();
             },
             (error) => {
               const log: Log = {

--- a/src/providers/global/state-reforming.service.ts
+++ b/src/providers/global/state-reforming.service.ts
@@ -23,6 +23,7 @@ export class StateReformingService {
         if (view.name == PAGE_NAMES.COMPLETE_TEST_PAGE) continue;
         if (view.name == PAGE_NAMES.TEST_REVIEW_PAGE) continue;
         if (view.name == PAGE_NAMES.SIGNATURE_PAD_PAGE) continue;
+        if (view.name == PAGE_NAMES.TEST_CANCEL_PAGE) continue;
         stateHistory.push({
           page: view.name,
           params: view.data


### PR DESCRIPTION
A new test is created if the last test in a visit ( read from local storage) doesn't have set an endTime.
This check is done in the handler of the popup present in the 'add preparer' page, which I couldn't move because it was breaking other things (closing the app from the 'add preparer'  page was again repopulating the old test)
To make the app work correctly, I just had to persist the endTime to local storage after it was set on the test