### PR TITLE
CVSB-11773 Storing test history for each vehicle separately

### DIFF
--- a/src/pages/testing/vehicle/vehicle-details/vehicle-details.ts
+++ b/src/pages/testing/vehicle/vehicle-details/vehicle-details.ts
@@ -119,7 +119,7 @@ export class VehicleDetailsPage {
   }
 
   goToVehicleTestResultsHistory() {
-    this.storageService.read(STORAGE.TEST_HISTORY).then(
+    this.storageService.read(STORAGE.TEST_HISTORY+this.vehicleData.systemNumber).then(
       data => {
         this.navCtrl.push(PAGE_NAMES.VEHICLE_HISTORY_PAGE, {
           vehicleData: this.vehicleData,

--- a/src/pages/testing/vehicle/vehicle-lookup/multiple-tech-records-selection/multiple-tech-records-selection.ts
+++ b/src/pages/testing/vehicle/vehicle-lookup/multiple-tech-records-selection/multiple-tech-records-selection.ts
@@ -65,7 +65,7 @@ export class MultipleTechRecordsSelectionPage implements OnInit {
           content_type: 'error',
           item_id: "Failed retrieving the testResultsHistory"
         });
-        this.storageService.update(STORAGE.TEST_HISTORY, []);
+        this.storageService.update(STORAGE.TEST_HISTORY+selectedVehicle.systemNumber, []);
         this.goToVehicleDetails(selectedVehicle);
       },
       complete: function () {}

--- a/src/pages/testing/vehicle/vehicle-lookup/vehicle-lookup.spec.ts
+++ b/src/pages/testing/vehicle/vehicle-lookup/vehicle-lookup.spec.ts
@@ -15,7 +15,7 @@ import { CallNumber } from "@ionic-native/call-number";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { TestDataModelMock } from "../../../../assets/data-mocks/data-model/test-data-model.mock";
 import { VehicleDataMock } from "../../../../assets/data-mocks/vehicle-data.mock";
-import { APP_STRINGS, VEHICLE_TYPE } from "../../../../app/app.enums";
+import {APP_STRINGS, STORAGE, VEHICLE_TYPE} from '../../../../app/app.enums';
 import { AuthService } from "../../../../providers/global/auth.service";
 import { AuthServiceMock } from "../../../../../test-config/services-mocks/auth-service.mock";
 import { Store } from "@ngrx/store";
@@ -25,6 +25,8 @@ import { FirebaseLogsServiceMock } from "../../../../../test-config/services-moc
 import { AppService } from '../../../../providers/global/app.service';
 import { AppServiceMock } from '../../../../../test-config/services-mocks/app-service.mock';
 import { VehicleLookupSearchCriteriaData } from "../../../../assets/app-data/vehicle-lookup-search-criteria/vehicle-lookup-search-criteria.data";
+import {_throw} from 'rxjs/observable/throw';
+import {of} from 'rxjs/observable/of';
 
 describe('Component: VehicleLookupPage', () => {
   let component: VehicleLookupPage;
@@ -33,6 +35,7 @@ describe('Component: VehicleLookupPage', () => {
   let storageService: StorageServiceMock;
   let firebaseLogsService: FirebaseLogsService;
   let modalCtrl: ModalController;
+  let vehicleService: VehicleService;
 
   const TEST_DATA = TestDataModelMock.TestData;
   const VEHICLE = VehicleDataMock.VehicleData;
@@ -72,12 +75,16 @@ describe('Component: VehicleLookupPage', () => {
     storageService = TestBed.get(StorageService);
     firebaseLogsService = TestBed.get(FirebaseLogsService);
     modalCtrl = TestBed.get(ModalController);
+    vehicleService = TestBed.get(VehicleService);
+
+    component.selectedSearchCriteria = 'Registration number, VIN or trailer ID';
   });
 
   afterEach(() => {
     fixture.destroy();
     component = null;
     storageService = null;
+    vehicleService = null;
   });
 
   it('should create the component', () => {
@@ -115,5 +122,14 @@ describe('Component: VehicleLookupPage', () => {
   it('should get the right queryParam for techRecords call based on selected search criteria', () => {
     component.selectedSearchCriteria = VehicleLookupSearchCriteriaData.VehicleLookupSearchCriteria[4];
     expect(component.getTechRecordQueryParam().queryParam).toEqual('trailerId');
+  });
+
+  it('should empty ionic storage if the test history cannot be retrieved', ()=> {
+    spyOn(storageService, 'update');
+    vehicleService.getVehicleTechRecords = jasmine.createSpy().and.callFake(() => of([VEHICLE]));
+    vehicleService.getTestResultsHistory = jasmine.createSpy().and.callFake(() => _throw('Error'));
+    component.searchVehicle('TESTVIN');
+    expect(storageService.update).toHaveBeenCalledTimes(1);
+    expect(storageService.update).toHaveBeenCalledWith(STORAGE.TEST_HISTORY+VEHICLE.systemNumber, []);
   });
 });

--- a/src/pages/testing/vehicle/vehicle-lookup/vehicle-lookup.ts
+++ b/src/pages/testing/vehicle/vehicle-lookup/vehicle-lookup.ts
@@ -106,7 +106,7 @@ export class VehicleLookupPage {
                 content_type: 'error',
                 item_id: "Failed retrieving the testResultsHistory"
               });
-              this.storageService.update(STORAGE.TEST_HISTORY, []);
+              this.storageService.update(STORAGE.TEST_HISTORY+vehicleData[0].systemNumber, []);
               this.goToVehicleDetails(vehicleData[0]);
             },
             complete: function () {}

--- a/src/providers/vehicle/vehicle.service.spec.ts
+++ b/src/providers/vehicle/vehicle.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from "@angular/core/testing";
+import {async, TestBed} from "@angular/core/testing";
 import { TechRecordDataMock } from "../../assets/data-mocks/tech-record-data.mock";
 import { TestTypeModel } from "../../models/tests/test-type.model";
 import { TestTypeDataModelMock } from "../../assets/data-mocks/data-model/test-type-data-model.mock";
@@ -7,7 +7,7 @@ import { VisitServiceMock } from "../../../test-config/services-mocks/visit-serv
 import { HTTPService } from "../global/http.service";
 import { VehicleService } from "./vehicle.service";
 import { PreparersReferenceDataModel } from "../../models/reference-data-models/preparers.model";
-import { ODOMETER_METRIC, TEST_TYPE_RESULTS } from "../../app/app.enums";
+import {ODOMETER_METRIC, STORAGE, TEST_TYPE_RESULTS} from "../../app/app.enums";
 import { VehicleTechRecordModel } from "../../models/vehicle/tech-record.model";
 import { VehicleDataMock } from "../../assets/data-mocks/vehicle-data.mock";
 import { Store } from "@ngrx/store";
@@ -168,9 +168,12 @@ describe('Provider: VehicleService', () => {
     expect(onlyOne).toBeTruthy();
   });
 
-  it('should test if the storage gets updated with newest test results history', () => {
+  it('should update ionic storage when retrieving test results history', async(() => {
+    const systemNumber = '10000000';
     spyOn(storageService, 'update');
-    vehicleService.getTestResultsHistory('10000000').subscribe();
-    expect(storageService.update).toHaveBeenCalledTimes(1);
-  });
+    vehicleService.getTestResultsHistory(systemNumber).subscribe(() => {
+      expect(storageService.update).toHaveBeenCalledTimes(1);
+      expect(storageService.update).toHaveBeenCalledWith(STORAGE.TEST_HISTORY+systemNumber, TestResultsHistoryDataMock.TestResultHistoryData);
+    });
+  }));
 });

--- a/src/providers/vehicle/vehicle.service.ts
+++ b/src/providers/vehicle/vehicle.service.ts
@@ -96,7 +96,7 @@ export class VehicleService {
           timestamp: Date.now(),
         };
         this.store$.dispatch(new logsActions.SaveLog(log));
-        this.storageService.update(STORAGE.TEST_HISTORY, data.body);
+        this.storageService.update(STORAGE.TEST_HISTORY+systemNumber, data.body);
         return data.body;
       });
   }


### PR DESCRIPTION
I built this solution on top of duplicate chassis to avoid conflicts with the vehicle lookup refactored logic.