### PR TITLE
fix(cvsb-13805): display PRS button for voluntary IVA/IVA retests

### DIFF
--- a/src/assets/app-data/test-types-data/test-types-fields.metadata.ts
+++ b/src/assets/app-data/test-types-data/test-types-fields.metadata.ts
@@ -4274,6 +4274,11 @@ export class TestTypesFieldsMetadata {
                     text: 'Fail',
                     value: TEST_TYPE_RESULTS.FAIL,
                     cssClass: 'danger-action-button'
+                  },
+                  {
+                    text: 'Prs',
+                    value: TEST_TYPE_RESULTS.PRS,
+                    cssClass: 'prs-action-button'
                   }
                 ],
                 defaultValue: 'Select',
@@ -4307,6 +4312,11 @@ export class TestTypesFieldsMetadata {
                     text: 'Fail',
                     value: TEST_TYPE_RESULTS.FAIL,
                     cssClass: 'danger-action-button'
+                  },
+                  {
+                    text: 'Prs',
+                    value: TEST_TYPE_RESULTS.PRS,
+                    cssClass: 'prs-action-button'
                   }
                 ],
                 defaultValue: 'Select',
@@ -5537,6 +5547,11 @@ export class TestTypesFieldsMetadata {
                     text: 'Fail',
                     value: TEST_TYPE_RESULTS.FAIL,
                     cssClass: 'danger-action-button'
+                  },
+                  {
+                    text: 'Prs',
+                    value: TEST_TYPE_RESULTS.PRS,
+                    cssClass: 'prs-action-button'
                   }
                 ],
                 defaultValue: 'Select',


### PR DESCRIPTION
## Ticket title
PRS button not appearing for Voluntary IVA

[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-13805)

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number