### PR TITLE
feat(19175): amend CSS for vehicle reg mark boxes

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -290,8 +290,10 @@ ion-item-group {
 .vehicle-header-vrm-number {
   -webkit-text-size-adjust: $disable-accessibility-text-scaling;
   background: $color-reg-plate;
-  width: 194px;
-  height: 50px;
+  min-width: 200px;
+  width: fit-content;
+  min-height: 50px;
+  height: fit-content;
   font-size: $font-size-extra-large;
   font-weight: $font-weight-bold;
   line-height: 42px;

--- a/src/pages/testing/vehicle/add-preparer/add-preparer.html
+++ b/src/pages/testing/vehicle/add-preparer/add-preparer.html
@@ -11,17 +11,12 @@
 
 <ion-content no-padding>
   <ion-grid no-padding>
-    <ion-row justify-content-center>
-      <ion-col col-6>
-        <div text-uppercase text-center class="vehicle-header-vrm-number">
-          <ng-container
-            *ngIf="checkForMatch(vehicleData.techRecord.vehicleType,VEHICLE_TYPE.TRL); else isVehicle"
-            >{{ vehicleData.trailerId }}</ng-container
-          >
+     <div text-uppercase text-center class="vehicle-header-vrm-number">
+          <ng-container *ngIf="checkForMatch(vehicleData.techRecord.vehicleType,VEHICLE_TYPE.TRL); else isVehicle">
+            {{ vehicleData.trailerId }}
+          </ng-container>
           <ng-template #isVehicle>{{ vehicleData.vrm | formatVrm }}</ng-template>
         </div>
-      </ion-col>
-    </ion-row>
     <ion-row no-border>
       <ion-item padding-left class="srch-preparer-input">
         <ion-input


### PR DESCRIPTION
## Ticket title
Extend vehicle id box to display longer vrms correctly
https://jira.dvsacloud.uk/browse/CVSB-19175

<img width="424" alt="129701341-27968127-16e3-42b3-8a68-ce653ea5b3a8" src="https://user-images.githubusercontent.com/36958694/130928908-705b21c1-4a07-49a1-bbb6-21132a6d4e35.png">
<img width="418" alt="129701343-5d13d477-0a74-47b2-96cb-22b868f9fac0" src="https://user-images.githubusercontent.com/36958694/130928909-e2acf392-4da8-4f8d-b136-a6c5d8b1d9de.png">

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number