### PR TITLE
fix(cvsb-19681): prohibition toggle saved without selecting CTA to save

### DIFF
--- a/src/pages/testing/defects/defect-details/defect-details.ts
+++ b/src/pages/testing/defects/defect-details/defect-details.ts
@@ -40,6 +40,7 @@ export class DefectDetailsPage implements OnInit {
   isLocation: boolean;
   tempDefectLocation: DefectLocationModel;
   tempDefectNotes: string;
+  tempProhibition: boolean;
   fromTestReview: boolean;
   showPrs: boolean = true;
   notesChanged: boolean = false;
@@ -68,6 +69,7 @@ export class DefectDetailsPage implements OnInit {
   ngOnInit() {
     this.tempDefectLocation = Object.assign({}, this.defect.additionalInformation.location);
     this.tempDefectNotes = this.defect.additionalInformation.notes;
+    this.tempProhibition = this.defect.prohibitionIssued;
     this.defectMetadata = this.defect.metadata.category.additionalInfo;
     this.isLocation =
       this.defectMetadata && this.defectMetadata.location
@@ -87,6 +89,7 @@ export class DefectDetailsPage implements OnInit {
     this.navBar.backButtonClick = () => {
       this.defect.additionalInformation.location = Object.assign({}, this.tempDefectLocation);
       this.defect.additionalInformation.notes = this.tempDefectNotes;
+      this.defect.prohibitionIssued = this.tempProhibition;
       this.navCtrl.pop();
     };
   }


### PR DESCRIPTION
KT - (FE) Prohibition toggle saved without selecting VTA to save
Fixed the back button saving the users Prohibition selection when editing a defect.
[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-19681)

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number