### PR TITLE
fix(cvsb-4657): dismissed alert after call button is pressed

### DIFF
--- a/src/pages/testing/vehicle/vehicle-details/vehicle-details.ts
+++ b/src/pages/testing/vehicle/vehicle-details/vehicle-details.ts
@@ -153,6 +153,7 @@ export class VehicleDetailsPage {
                             (data) => console.log(data),
                             (err) => console.log(err)
                           );
+                          alert.dismiss();
                           return false;
                         }
                       }


### PR DESCRIPTION
User is not taken back to 'Vehicle details' screen after cancelling call
Added an alert.dismiss() for the alert after Call is clicked.
[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-4657)

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number