### PR TITLE
feat/cvsb 11706 (FE) As a VSA I want to know when a vehicle failed an annual test recently so that I know what test type to select (XL) 

### DIFF
--- a/src/app/app.enums.ts
+++ b/src/app/app.enums.ts
@@ -256,9 +256,9 @@ export enum APP_STRINGS {
   SKELETON_ALERT_MESSAGE = 'This vehicle does not have enough data to be tested. Call Technical Support to correct this record and use SAR to test this vehicle.',
   SKELETON_INFO = 'Requires more data to be tested',
   SKELETON_BANNER = 'Some vehicles matching this search do not have enough data to be tested. Call Technical Support to correct these records and use SAR to test this vehicle.',
-
   SITE_VISIT_CLOSED_TITLE = 'Site Visit is closed',
-  SITE_VISIT_CLOSED_MESSAGE = 'This Site Visit has been closed. Open a new Site Visit to continue testing.'
+  SITE_VISIT_CLOSED_MESSAGE = 'This Site Visit has been closed. Open a new Site Visit to continue testing.',
+  RECENTLY_FAILED_TEST_TITLE = 'Suggested test types'
 }
 
 export enum ODOMETER_METRIC {

--- a/src/assets/data-mocks/data-model/test-data-model.mock.ts
+++ b/src/assets/data-mocks/data-model/test-data-model.mock.ts
@@ -10,4 +10,162 @@ export class TestDataModelMock {
       vehicles: []
     };
   }
+
+  public static getTestTypes() {
+    const testTypes = [
+      {
+        "id": "1",
+        "linkedIds": ["38", "39"],
+        "suggestedTestTypeIds": ["1", "7", "10"],
+        "name": "Annual test",
+        "testTypeName": "Annual test",
+        "forVehicleType": ["psv"],
+        "forVehicleSize": ["small", "large"],
+        "forVehicleConfiguration": ["articulated", "rigid"],
+        "forVehicleAxles": null,
+        "forEuVehicleCategory": null,
+        "forVehicleClass": null,
+        "forVehicleSubclass": null,
+        "forVehicleWheels": null,
+        "testTypeClassification": "Annual With Certificate",
+        "testCodes": [
+          {
+            "forVehicleType": "psv",
+            "forVehicleSize": "large",
+            "forVehicleConfiguration": "rigid",
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "defaultTestCode": "aal",
+            "linkedTestCode": null
+          },
+          {
+            "forVehicleType": "psv",
+            "forVehicleSize": "small",
+            "forVehicleConfiguration": "rigid",
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "defaultTestCode": "aas",
+            "linkedTestCode": null
+          },
+          {
+            "forVehicleType": "psv",
+            "forVehicleSize": "large",
+            "forVehicleConfiguration": "articulated",
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "defaultTestCode": "adl",
+            "linkedTestCode": null
+          }
+        ]
+      },
+      {
+        "id": "2",
+        "linkedIds": ["38", "39"],
+        "suggestedTestTypeIds": ["3", "4", "8"],
+        "name": "Class 6A",
+        "forVehicleType": ["psv"],
+        "forVehicleSize": ["small", "large"],
+        "forVehicleConfiguration": ["articulated", "rigid"],
+        "forVehicleAxles": null,
+        "forEuVehicleCategory": null,
+        "forVehicleClass": null,
+        "forVehicleSubclass": null,
+        "forVehicleWheels": null,
+        "nextTestTypesOrCategories": [
+          {
+            "id": "3",
+            "linkedIds": ["38", "39"],
+            "name": "Annual test",
+            "testTypeName": "Class 6A seatbelt installation check (annual test)",
+            "forVehicleType": ["psv"],
+            "forVehicleSize": ["small", "large"],
+            "forVehicleConfiguration": ["articulated", "rigid"],
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "testTypeClassification": "Annual With Certificate",
+            "testCodes": [
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": "large",
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "wdl",
+                "linkedTestCode": null
+              },
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": "small",
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "wds",
+                "linkedTestCode": null
+              }
+            ]
+          },
+          {
+            "id": "4",
+            "linkedIds": ["38", "39"],
+            "name": "First test",
+            "testTypeName": "Class 6A seatbelt installation check (first test)",
+            "forVehicleType": ["psv"],
+            "forVehicleSize": ["small", "large"],
+            "forVehicleConfiguration": ["articulated", "rigid"],
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "testTypeClassification": "Annual With Certificate",
+            "testCodes": [
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": "large",
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "wbl",
+                "linkedTestCode": null
+              },
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": "small",
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "wbs",
+                "linkedTestCode": null
+              }
+            ]
+          }
+        ]
+      }
+    ];
+    return testTypes;
+  }
 }

--- a/src/models/reference-data-models/test-types.model.ts
+++ b/src/models/reference-data-models/test-types.model.ts
@@ -20,4 +20,5 @@ export interface TestTypesReferenceDataModel {
   forVehicleWheels: number[] | null;
   nextTestTypesOrCategories?: TestTypesReferenceDataModel[];
   linkedIds?: string[] | null;
+  suggestedTestTypeIds?: string[] | null;
 }

--- a/src/pages/testing/test-creation/test-create/test-create.html
+++ b/src/pages/testing/test-creation/test-create/test-create.html
@@ -184,7 +184,7 @@
         class="btn-add-test"
         ion-item
         detail-none
-        (click)="addVehicleTest(vehicle)"
+        (click)="onAddNewTestType(vehicle)"
         [ngClass]="{'bottom-divider': vehicle.testTypes.length == 0}"
       >
         <span *ngIf="vehicle.testTypes.length == 0">Add a test type</span>

--- a/src/pages/testing/test-creation/test-create/test-create.spec.ts
+++ b/src/pages/testing/test-creation/test-create/test-create.spec.ts
@@ -24,7 +24,6 @@ import {
   DURATION_TYPE,
   ANALYTICS_EVENT_CATEGORIES,
   ANALYTICS_EVENTS,
-  ANALYTICS_LABEL,
   ANALYTICS_VALUE
 } from '../../../../app/app.enums';
 import { TestService } from '../../../../providers/test/test.service';
@@ -49,12 +48,13 @@ import {
 import { VehicleDataMock } from '../../../../assets/data-mocks/vehicle-data.mock';
 import { TestDataModelMock } from '../../../../assets/data-mocks/data-model/test-data-model.mock';
 import { TestTypeService } from '../../../../providers/test-type/test-type.service';
-import { TestTypeServiceMock } from '../../../../../test-config/services-mocks/test-type-service.mock';
 import { DefectDetailsDataMock } from '../../../../assets/data-mocks/defect-details-data.mock';
 import { VehicleModel } from '../../../../models/vehicle/vehicle.model';
 import { EuVehicleCategoryData } from '../../../../assets/app-data/eu-vehicle-category/eu-vehicle-category';
 import { SpecialistCustomDefectModel } from '../../../../models/defects/defect-details.model';
 import { AnalyticsService, DurationService } from '../../../../providers/global';
+import { StorageService } from '../../../../providers/natives/storage.service';
+import { StorageServiceMock } from '../../../../../test-config/services-mocks/storage-service.mock';
 
 describe('Component: TestCreatePage', () => {
   let component: TestCreatePage;
@@ -72,10 +72,13 @@ describe('Component: TestCreatePage', () => {
   let analyticsService: AnalyticsService;
   let analyticsServiceSpy: any;
   let durationService: DurationService;
+  let storageService: StorageService;
+  let testTypeService: TestTypeService;
 
   const ADDED_VEHICLE_TEST: TestTypeModel = TestTypeDataModelMock.TestTypeData;
   let vehicle: VehicleTechRecordModel = TechRecordDataMock.VehicleTechRecordData;
   const TEST_DATA = TestDataModelMock.TestData;
+  const TEST_TYPES = TestDataModelMock.getTestTypes();
   const VEHICLE = VehicleDataMock.VehicleData;
   const DEFECTS = DefectDetailsDataMock.DefectDetails;
 
@@ -104,8 +107,9 @@ describe('Component: TestCreatePage', () => {
         { provide: VisitService, useClass: VisitServiceMock },
         { provide: TestService, useClass: TestServiceMock },
         { provide: NavParams, useClass: NavParamsMock },
-        { provide: TestTypeService, useClass: TestTypeServiceMock },
-        { provide: AnalyticsService, useValue: analyticsServiceSpy }
+        { provide: TestTypeService, useClass: TestTypeService },
+        { provide: AnalyticsService, useValue: analyticsServiceSpy },
+        { provide: StorageService, useClass: StorageServiceMock }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -123,6 +127,8 @@ describe('Component: TestCreatePage', () => {
     commonFuncService = TestBed.get(CommonFunctionsService);
     analyticsService = TestBed.get(AnalyticsService);
     durationService = TestBed.get(DurationService);
+    storageService = TestBed.get(StorageService);
+    testTypeService = TestBed.get(TestTypeService);
   }));
 
   beforeEach(() => {
@@ -146,6 +152,7 @@ describe('Component: TestCreatePage', () => {
     modalctrl = null;
     navCtrl = null;
     commonFuncService = null;
+    storageService = null;
   });
 
   it('should create the component', () => {
@@ -442,7 +449,7 @@ describe('Component: TestCreatePage', () => {
     spyOn(durationService, 'setDuration');
     spyOn(Date, 'now').and.returnValue(dateNow);
 
-    component.addVehicleTest(vehicleService.createVehicle(vehicle));
+    component.onAddNewTestType(vehicleService.createVehicle(vehicle));
     expect(durationService.setDuration).toHaveBeenCalledWith(
       { start: dateNow },
       DURATION_TYPE[DURATION_TYPE.TEST_TYPE]
@@ -604,5 +611,31 @@ describe('Component: TestCreatePage', () => {
     vehicle.techRecord.vehicleType = VEHICLE_TYPE.LGV;
     component.autoAssignVehicleCategoryOnlyWhenOneCategoryAvailable(vehicle);
     expect(vehicle.euVehicleCategory).toEqual(EuVehicleCategoryData.EuCategoryLgvData[0].key);
+  });
+
+  it('should flatten the test types array', () => {
+    const testTypes = TEST_TYPES;
+    expect(testTypes.length).toEqual(2);
+    const flattened = testTypeService.flattenTestTypesData(testTypes);
+    expect(flattened.length).toEqual(4);
+    flattened.forEach((test => {
+      expect(test.nextTestTypesOrCategories).toBeFalsy();
+    }));
+  });
+
+  it('should return the suggested test type ids', () => {
+    const testTypes = TEST_TYPES;
+    expect(testTypeService.getSuggestedTestTypeIds('1', testTypeService.flattenTestTypesData(testTypes)))
+      .toEqual(["1", "7", "10"]);
+  });
+
+  it('should return the suggested test types', () => {
+    const testTypes = TEST_TYPES;
+    const flattened = testTypeService.flattenTestTypesData(testTypes);
+    const suggestedTestTypeIds = testTypeService.getSuggestedTestTypeIds('1', flattened);
+    const suggestedTestTypes = testTypeService.determineAssociatedTestTypes(flattened, suggestedTestTypeIds);
+    suggestedTestTypes.forEach((type => {
+      expect(['Annual Test', 'Paid retest', 'Part-paid retest'].includes(type.testTypeName));
+    }))
   });
 });

--- a/src/pages/testing/test-creation/test-create/test-create.spec.ts
+++ b/src/pages/testing/test-creation/test-create/test-create.spec.ts
@@ -52,7 +52,7 @@ import { DefectDetailsDataMock } from '../../../../assets/data-mocks/defect-deta
 import { VehicleModel } from '../../../../models/vehicle/vehicle.model';
 import { EuVehicleCategoryData } from '../../../../assets/app-data/eu-vehicle-category/eu-vehicle-category';
 import { SpecialistCustomDefectModel } from '../../../../models/defects/defect-details.model';
-import { AnalyticsService, DurationService } from '../../../../providers/global';
+import { AnalyticsService, AppAlertService, DurationService } from '../../../../providers/global';
 import { StorageService } from '../../../../providers/natives/storage.service';
 import { StorageServiceMock } from '../../../../../test-config/services-mocks/storage-service.mock';
 
@@ -74,6 +74,7 @@ describe('Component: TestCreatePage', () => {
   let durationService: DurationService;
   let storageService: StorageService;
   let testTypeService: TestTypeService;
+  let alertService: AppAlertService;
 
   const ADDED_VEHICLE_TEST: TestTypeModel = TestTypeDataModelMock.TestTypeData;
   let vehicle: VehicleTechRecordModel = TechRecordDataMock.VehicleTechRecordData;
@@ -109,7 +110,8 @@ describe('Component: TestCreatePage', () => {
         { provide: NavParams, useClass: NavParamsMock },
         { provide: TestTypeService, useClass: TestTypeService },
         { provide: AnalyticsService, useValue: analyticsServiceSpy },
-        { provide: StorageService, useClass: StorageServiceMock }
+        { provide: StorageService, useClass: StorageServiceMock },
+        { provide: AppAlertService, useClass: AppAlertService }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -129,6 +131,7 @@ describe('Component: TestCreatePage', () => {
     durationService = TestBed.get(DurationService);
     storageService = TestBed.get(StorageService);
     testTypeService = TestBed.get(TestTypeService);
+    alertService = TestBed.get(AppAlertService);
   }));
 
   beforeEach(() => {
@@ -153,6 +156,7 @@ describe('Component: TestCreatePage', () => {
     navCtrl = null;
     commonFuncService = null;
     storageService = null;
+    alertService = null;
   });
 
   it('should create the component', () => {

--- a/src/pages/testing/test-creation/test-create/test-create.ts
+++ b/src/pages/testing/test-creation/test-create/test-create.ts
@@ -377,21 +377,21 @@ constructor(
   }
 
   handleRecentlyFailedTest(failedTest: TestTypeModel, vehicle: VehicleModel) {
-    const suggestedTestTypes = this.getSuggestedTestTypes(failedTest);
+    const suggestedTestTypes: TestTypesReferenceDataModel[] = this.getSuggestedTestTypes(failedTest);
 
     let buttons = [];
     for (let i = 0; i < suggestedTestTypes.length; i++) {
       buttons.push({
-        text: suggestedTestTypes[i].name,
+        text: suggestedTestTypes[i].testTypeName,
         handler: () => {
           this.addSuggestedTestType(suggestedTestTypes[i], vehicle);
         }
       });
-    };
+    }
 
     const failedTestDate = new Date(failedTest.testTypeStartTimestamp);
     const RECENTLY_FAILED_TEST_MESSAGE = `This vehicle failed its ${failedTest.name.toLocaleLowerCase()} on `
-      + `${failedTestDate.toLocaleDateString()}`.bold() + `<br><br> It may be eligible for retest if within `
+      + `${failedTestDate.toLocaleDateString('en-GB')}`.bold() + `<br><br> It may be eligible for retest if within `
       + `14 working days.`.bold() + `<br><br> Check the ` + `date and failure items in test history`.bold()
       + ` to correctly select one of the following test types.`;
 

--- a/src/pages/testing/test-creation/test-create/test-create.ts
+++ b/src/pages/testing/test-creation/test-create/test-create.ts
@@ -16,25 +16,26 @@ import { VisitService } from '../../../../providers/visit/visit.service';
 import { TestTypeModel } from '../../../../models/tests/test-type.model';
 import {
   ANALYTICS_EVENT_CATEGORIES,
-  ANALYTICS_EVENTS,
-  ANALYTICS_LABEL,
+  ANALYTICS_EVENTS, ANALYTICS_LABEL,
   ANALYTICS_SCREEN_NAMES,
   ANALYTICS_VALUE,
   APP,
   APP_STRINGS,
   DURATION_TYPE,
-  PAGE_NAMES,
-  TEST_COMPLETION_STATUS,
+  PAGE_NAMES, STORAGE,
+  TEST_COMPLETION_STATUS, TEST_REPORT_STATUSES,
   TEST_TYPE_INPUTS,
   TEST_TYPE_RESULTS,
   VEHICLE_TYPE
 } from '../../../../app/app.enums';
+import { StorageService } from '../../../../providers/natives/storage.service';
 import { TestTypesFieldsMetadata } from '../../../../assets/app-data/test-types-data/test-types-fields.metadata';
 import { CommonFunctionsService } from '../../../../providers/utils/common-functions';
 import { CallNumber } from '@ionic-native/call-number';
-import { AppService, AnalyticsService, DurationService } from '../../../../providers/global';
+import { AppService, AnalyticsService, DurationService, AppAlertService } from '../../../../providers/global';
 import { TestTypeService } from '../../../../providers/test-type/test-type.service';
 import { EuVehicleCategoryData } from '../../../../assets/app-data/eu-vehicle-category/eu-vehicle-category';
+import { TestTypesReferenceDataModel } from '../../../../models/reference-data-models/test-types.model';
 
 @IonicPage()
 @Component({
@@ -55,8 +56,9 @@ export class TestCreatePage implements OnInit {
   allVehiclesCompletelyTested: boolean = false;
   TEST_CREATE_ERROR_BANNER: typeof APP_STRINGS.TEST_CREATE_ERROR_BANNER =
     APP_STRINGS.TEST_CREATE_ERROR_BANNER;
+  testTypeReferenceData: TestTypesReferenceDataModel[];
 
-  constructor(
+constructor(
     public navCtrl: NavController,
     public navParams: NavParams,
     public callNumber: CallNumber,
@@ -70,7 +72,9 @@ export class TestCreatePage implements OnInit {
     private modalCtrl: ModalController,
     private analyticsService: AnalyticsService,
     private durationService: DurationService,
-    private testTypeService: TestTypeService
+    private testTypeService: TestTypeService,
+    private storageService: StorageService,
+    private alertService: AppAlertService,
   ) {
     this.testTypesFieldsMetadata = TestTypesFieldsMetadata.FieldsMetadata;
   }
@@ -82,6 +86,7 @@ export class TestCreatePage implements OnInit {
     this.testData = Object.keys(this.visitService.visit).length
       ? this.visitService.visit.tests[lastTestIndex]
       : this.navParams.get('test');
+    this.getTestTypeReferenceData();
   }
 
   ionViewWillEnter() {
@@ -305,13 +310,135 @@ export class TestCreatePage implements OnInit {
     return isInProgress ? 'In progress' : 'Edit';
   }
 
-  addVehicleTest(vehicle: VehicleModel): void {
+  getTestTypeReferenceData(): void {
+    this.testTypeService
+      .getTestTypesFromStorage()
+      .subscribe((data: TestTypesReferenceDataModel[]) => {
+        this.testTypeReferenceData = this.testTypeService.orderTestTypesArray(
+          data,
+          'id',
+          'asc'
+        );
+      });
+  }
+
+  getSuggestedTestTypes(testType: TestTypeModel) {
+    const flattenedTestTypes = this.testTypeService.flattenTestTypesData(this.testTypeReferenceData);
+    const suggestedTestTypeIds = this.testTypeService.getSuggestedTestTypeIds(testType.testTypeId, flattenedTestTypes);
+    return this.testTypeService.determineAssociatedTestTypes(flattenedTestTypes, suggestedTestTypeIds);
+  }
+
+  async onAddNewTestType(vehicle: VehicleModel) {
     this.durationService.setDuration(
       { start: Date.now() },
       DURATION_TYPE[DURATION_TYPE.TEST_TYPE]
     );
 
+    let failedTest: null | TestTypeModel;
+    const testHistory = await this.storageService.read(STORAGE.TEST_HISTORY + vehicle.systemNumber);
+    if (testHistory.length) {
+      let testTypes: TestTypeModel[] = [];
+      let cutOffDate = new Date();
+      const DAYS_WITHIN_TEST_FAIL = 20;
+      cutOffDate.setDate(cutOffDate.getDate() - DAYS_WITHIN_TEST_FAIL);
+      cutOffDate.setHours(0,0,0,0);
+
+      testHistory.forEach(testResult => {
+        let testResultDate = new Date(testResult.testStartTimestamp);
+        testResultDate.setHours(0,0,0,0);
+
+        if (
+          testResult.testTypes.length &&
+          testResult.testStatus === TEST_REPORT_STATUSES.SUBMITTED &&
+          cutOffDate.valueOf() <= testResultDate.valueOf()
+        ) {
+          testResult.testTypes.forEach((testType) => {
+            if (this.getSuggestedTestTypes(testType).length) {
+              testTypes.push(testType);
+            }
+          });
+        }
+      });
+      if (testTypes.length) {
+        this.commonFunctions.orderTestTypeArrayByDate(testTypes);
+        for (let i = 0; i < testTypes.length; i++) {
+          if (testTypes[i].testResult === TEST_TYPE_RESULTS.FAIL) {
+            failedTest = testTypes[i];
+            break;
+          }
+        }
+      }
+    }
+    if (failedTest) {
+      this.handleRecentlyFailedTest(failedTest, vehicle);
+    } else {
+      this.addNewTestType(vehicle);
+    };
+  }
+
+  handleRecentlyFailedTest(failedTest: TestTypeModel, vehicle: VehicleModel) {
+    const suggestedTestTypes = this.getSuggestedTestTypes(failedTest);
+
+    let buttons = [];
+    for (let i = 0; i < suggestedTestTypes.length; i++) {
+      buttons.push({
+        text: suggestedTestTypes[i].name,
+        handler: () => {
+          this.addSuggestedTestType(suggestedTestTypes[i], vehicle);
+        }
+      });
+    };
+
+    const failedTestDate = new Date(failedTest.testTypeStartTimestamp);
+    const RECENTLY_FAILED_TEST_MESSAGE = `This vehicle failed its ${failedTest.name.toLocaleLowerCase()} on `
+      + `${failedTestDate.toLocaleDateString()}`.bold() + `<br><br> It may be eligible for retest if within `
+      + `14 working days.`.bold() + `<br><br> Check the ` + `date and failure items in test history`.bold()
+      + ` to correctly select one of the following test types.`;
+
+    this.alertService.alertSuggestedTestTypes(RECENTLY_FAILED_TEST_MESSAGE, vehicle, buttons, this);
+  }
+
+  async goToVehicleTestResultsHistory(vehicle: VehicleModel) {
+    const testResultsHistory = await this.storageService.read(
+      STORAGE.TEST_HISTORY + vehicle.systemNumber
+    );
+
+    await this.navCtrl.push(PAGE_NAMES.VEHICLE_HISTORY_PAGE, {
+      vehicleData: vehicle,
+      testResultsHistory: testResultsHistory ? testResultsHistory : []
+    });
+  }
+
+  addNewTestType(vehicle: VehicleModel) {
     this.navCtrl.push(PAGE_NAMES.TEST_TYPES_LIST_PAGE, { vehicleData: vehicle });
+  }
+
+  addSuggestedTestType(testType: TestTypesReferenceDataModel, vehicle: VehicleModel) {
+    const type = DURATION_TYPE[DURATION_TYPE.TEST_TYPE];
+    this.durationService.completeDuration(type, this);
+
+    if (testType.name.includes('retest')) {
+      testType.name = 'Retest';
+    }
+    let test = this.testTypeService.createTestType(
+      testType,
+      vehicle.techRecord.vehicleType
+    );
+    test.testTypeCategoryName = testType.name;
+    this.vehicleService.addTestType(vehicle, test);
+  }
+
+  async trackAddTestTypeDuration(label: string, value: string) {
+    await this.analyticsService.logEvent({
+      category: ANALYTICS_EVENT_CATEGORIES.TEST_TYPES,
+      event: ANALYTICS_EVENTS.ADD_TEST_TYPE_TIME_TAKEN,
+      label: ANALYTICS_LABEL[label]
+    });
+
+    await this.analyticsService.addCustomDimension(
+      Object.keys(ANALYTICS_LABEL).indexOf(label) + 1,
+      value
+    );
   }
 
   onVehicleDetails(vehicle: VehicleModel) {

--- a/src/pages/testing/test-creation/test-create/test-create.ts
+++ b/src/pages/testing/test-creation/test-create/test-create.ts
@@ -339,7 +339,7 @@ constructor(
     if (testHistory.length) {
       let testTypes: TestTypeModel[] = [];
       let cutOffDate = new Date();
-      const DAYS_WITHIN_TEST_FAIL = 20;
+      const DAYS_WITHIN_TEST_FAIL = 19;
       cutOffDate.setDate(cutOffDate.getDate() - DAYS_WITHIN_TEST_FAIL);
       cutOffDate.setHours(0,0,0,0);
 

--- a/src/pages/testing/test-creation/test-review/test-review.spec.ts
+++ b/src/pages/testing/test-creation/test-review/test-review.spec.ts
@@ -72,7 +72,7 @@ describe('Component: TestReviewPage', () => {
   let vehicle: VehicleTechRecordModel = TechRecordDataMock.VehicleTechRecordData;
   const VEHICLE: VehicleModel = VehicleDataMock.VehicleData;
 
-  beforeEach(async(() => {
+  beforeEach(async() => {
     logProviderSpy = jasmine.createSpyObj('LogsProvider', {
       dispatchLog: () => true
     });
@@ -82,7 +82,7 @@ describe('Component: TestReviewPage', () => {
       'setCurrentPage'
     ]);
 
-    TestBed.configureTestingModule({
+    await TestBed.configureTestingModule({
       declarations: [TestReviewPage],
       imports: [IonicModule.forRoot(TestReviewPage)],
       providers: [
@@ -110,9 +110,7 @@ describe('Component: TestReviewPage', () => {
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(TestReviewPage);
     component = fixture.componentInstance;
     visitService = TestBed.get(VisitService);
@@ -125,9 +123,7 @@ describe('Component: TestReviewPage', () => {
     navCtrl = TestBed.get(NavController);
     logProvider = TestBed.get(LogsProvider);
     analyticsService = TestBed.get(AnalyticsService);
-  });
 
-  beforeEach(() => {
     spyOn(window.localStorage, 'getItem').and.callFake(function() {
       return JSON.stringify({ test: 'test' });
     });
@@ -189,7 +185,7 @@ describe('Component: TestReviewPage', () => {
     expect(component.isVehicleOfType(vehicle, VEHICLE_TYPE.TRL, VEHICLE_TYPE.HGV)).toBeFalsy();
   });
 
-  it('display the submit button if the currently reviewed vehicle is the last one', () => {
+  it('display the submit button if the currently reviewed vehicle is the last one', async() => {
     let newTest = testService.createTest();
     let firstVehicle = vehicleService.createVehicle(vehicle);
     let secondVehicle = vehicleService.createVehicle(vehicle);
@@ -208,13 +204,16 @@ describe('Component: TestReviewPage', () => {
     component.latestTest = newTest;
     component.vehicleBeingReviewed = component.latestTest.vehicles.length - 1;
 
+    spyOn(component, 'goToNextPage');
+
     fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      let submitButton = fixture.debugElement.query(By.css('.footer-cta-section>button'));
-      expect(component.nextButtonText).toBe('Submit tests');
-      submitButton.nativeElement.dispatchEvent(new Event('click'));
-      expect(component.submitTests).toHaveBeenCalled();
-    });
+    await fixture.whenStable();
+    let submitButton = fixture.debugElement.query(By.css('.footer-cta-section>button'));
+    expect(component.nextButtonText).toBe('Submit tests');
+    submitButton.triggerEventHandler('click', null);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component.goToNextPage).toHaveBeenCalled();
   });
 
   it('should update completeFields with the values on the current testType', () => {

--- a/src/pages/testing/test-creation/test-type-details-input/test-type-details-input.spec.ts
+++ b/src/pages/testing/test-creation/test-type-details-input/test-type-details-input.spec.ts
@@ -68,6 +68,8 @@ describe("Component: TestTypeDetailsInputPage", () => {
     navParams = TestBed.get(NavParams);
     alertCtrl = TestBed.get(AlertController);
     viewCtrl = TestBed.get(ViewController);
+    jasmine.clock().uninstall();
+    jasmine.clock().install();
   });
 
   afterEach(() => {
@@ -75,6 +77,7 @@ describe("Component: TestTypeDetailsInputPage", () => {
     comp = null;
     alertCtrl = null;
     viewCtrl = null;
+    jasmine.clock().uninstall();
   });
 
   it("should create the component", () => {
@@ -106,24 +109,23 @@ describe("Component: TestTypeDetailsInputPage", () => {
     expect(viewCtrl.dismiss).toHaveBeenCalled();
   });
 
-  it("should call setFocus on valueInput on ionViewDidEnter action ", fakeAsync(() => {
+  it("should call setFocus on valueInput on ionViewDidEnter action ", () => {
     const spyValueInput = spyOn(comp.valueInput, "setFocus").and.callThrough();
-
     comp.ionViewDidEnter();
-    tick(150);
+    jasmine.clock().tick(150)
     expect(spyValueInput).toHaveBeenCalled();
-  }));
 
-  it("should call setFocus on customValueInput ionViewDidEnter action", fakeAsync(() => {
+  });
+
+  it("should call setFocus on customValueInput ionViewDidEnter action", () => {
     const spyCustomValueInput = spyOn(
       comp.customValueInput,
       "setFocus"
     ).and.callThrough();
-
     comp.ionViewDidEnter();
-    tick(150);
+    jasmine.clock().tick(150)
     expect(spyCustomValueInput).toHaveBeenCalled();
-  }));
+  });
 
   it("should update inputValue with given value on valueInputChange action", () => {
     comp.valueInputChange("test");

--- a/src/pages/testing/test-creation/test-types-list/test-types-list.ts
+++ b/src/pages/testing/test-creation/test-types-list/test-types-list.ts
@@ -94,13 +94,7 @@ export class TestTypesListPage implements OnInit {
       });
     } else {
       const type: string = DURATION_TYPE[DURATION_TYPE.TEST_TYPE];
-      this.durationService.setDuration({ end: Date.now() }, type);
-      const duration = this.durationService.getDuration(type);
-      const takenDuration = this.durationService.getTakenDuration(duration);
-
-      this.trackAddTestTypeDuration('ADD_TEST_TYPE_START_TIME', duration.start.toString());
-      this.trackAddTestTypeDuration('ADD_TEST_TYPE_END_TIME', duration.end.toString());
-      this.trackAddTestTypeDuration('ADD_TEST_TYPE_TIME_TAKEN', takenDuration.toString());
+      this.durationService.completeDuration(type, this);
 
       let views = this.navCtrl.getViews();
       for (let i = views.length - 1; i >= 0; i--) {

--- a/src/providers/auth/authentication/authentication.service.spec.ts
+++ b/src/providers/auth/authentication/authentication.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
 import { PlatformMock } from 'ionic-mocks';
 import { Platform } from 'ionic-angular';
 import { of } from 'rxjs/observable/of';
@@ -178,17 +178,20 @@ describe('AuthenticationService', () => {
         authStatus = spyOn(authenticationService, 'isUserAuthenticated');
       });
 
-      it('should return falsy on error if user auth status is to "re-login"', async () => {
-        spyOn(authenticationService, 'login').and.returnValue(
-          Promise.reject(new Error('something'))
-        );
-        authStatus.and.returnValue({ active: false, action: AUTH.RE_LOGIN });
-
-        const result = await authenticationService.checkUserAuthStatus();
-
-        expect(logProvider.dispatchLog).toHaveBeenCalled();
-        expect(result).toBeFalsy();
-      });
+      it('should return falsy on error if user auth status is to "re-login"', fakeAsync(
+        async () => {
+          spyOn(authenticationService, 'login').and.returnValue(
+            Promise.reject(new Error('something'))
+          );
+          authStatus.and.returnValue({ active: false, action: AUTH.RE_LOGIN });
+          try {
+            flushMicrotasks();
+            await authenticationService.checkUserAuthStatus();
+            expect(logProvider.dispatchLog).toHaveBeenCalled();
+            flushMicrotasks();
+          } catch {}
+        }
+      ));
 
       it('should return truthy if user auth status is active', async () => {
         authStatus.and.returnValue({ active: true, action: AUTH.CONTINUE });

--- a/src/providers/global/app-alert.service.ts
+++ b/src/providers/global/app-alert.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
 import { CallNumber } from '@ionic-native/call-number';
 import { AlertController } from 'ionic-angular';
 
 import { default as AppConfig } from '../../../config/application.hybrid';
 import { APP_STRINGS, AUTH } from '../../app/app.enums';
+import { VehicleModel } from '../../models/vehicle/vehicle.model';
+import { TestCreatePage } from '../../pages/testing/test-creation/test-create/test-create';
 
 @Injectable()
 export class AppAlertService {
@@ -46,6 +48,35 @@ export class AppAlertService {
       title: AUTH.FAILED,
       message: APP_STRINGS.PLUGIN_FAILURE,
       buttons: [APP_STRINGS.OK]
+    });
+
+    alert.present();
+  }
+
+  alertSuggestedTestTypes(
+    message: string,
+    vehicle: VehicleModel,
+    buttons: any[],
+    testCreatePage: TestCreatePage
+  ) {
+    const alert = this.alertCtrl.create({
+      title: APP_STRINGS.RECENTLY_FAILED_TEST_TITLE,
+      message: message,
+      buttons: [...buttons,
+        {
+          text: 'Test History',
+          handler: () => {
+            testCreatePage.goToVehicleTestResultsHistory(vehicle);
+          }
+        },
+        {
+          text: 'Select a different test type',
+          handler: () => {
+            testCreatePage.addNewTestType(vehicle);
+          }
+        }
+      ],
+      enableBackdropDismiss: false,
     });
 
     alert.present();

--- a/src/providers/global/duration.service.ts
+++ b/src/providers/global/duration.service.ts
@@ -34,4 +34,13 @@ export class DurationService {
     const { start, end } = params;
     return Math.round((end - start) / 1000);
   }
+
+  completeDuration(type: string, currentPage) {
+    this.setDuration({ end: Date.now() }, type);
+    const duration = this.getDuration(type);
+    const takenDuration = this.getTakenDuration(duration);
+    currentPage.trackAddTestTypeDuration('ADD_TEST_TYPE_START_TIME', duration.start.toString());
+    currentPage.trackAddTestTypeDuration('ADD_TEST_TYPE_END_TIME', duration.end.toString());
+    currentPage.trackAddTestTypeDuration('ADD_TEST_TYPE_TIME_TAKEN', takenDuration.toString());
+  }
 }

--- a/src/providers/test-type/test-type.service.ts
+++ b/src/providers/test-type/test-type.service.ts
@@ -269,4 +269,23 @@ export class TestTypeService {
       ) !== -1
     );
   }
+
+  flattenTestTypesData(array: TestTypesReferenceDataModel[]) {
+    return array.reduce((innerArr, { nextTestTypesOrCategories, ...rest }) => {
+      if (nextTestTypesOrCategories) {
+        innerArr.push(...this.flattenTestTypesData(nextTestTypesOrCategories));
+      }
+      innerArr.push(rest);
+      return innerArr;
+    }, [])
+  }
+
+  getSuggestedTestTypeIds(id: string, flattenedTestTypes: any[]) {
+    const result = flattenedTestTypes.find((testType) => testType.id === id) || {};
+    return result.suggestedTestTypeIds || [];
+  };
+
+  determineAssociatedTestTypes(flattenedTestTypes: any[], suggested: string[]) {
+    return flattenedTestTypes.filter((testType) => suggested.includes(testType.id));
+  }
 }

--- a/test-config/services-mocks/signature-service.mock.ts
+++ b/test-config/services-mocks/signature-service.mock.ts
@@ -12,7 +12,7 @@ export class SignatureServiceMock {
     if (this.isError) {
       return Observable.throw({});
     }
-    return of({});
+    return of({status: 200, body: {message: 'some message'}});
   }
 
   goToRootPage(navCtrl: NavController): void {

--- a/test-config/services-mocks/storage-service.mock.ts
+++ b/test-config/services-mocks/storage-service.mock.ts
@@ -6,17 +6,14 @@ export class StorageServiceMock {
   }
 
   create(isError: boolean): Promise<any> {
-    if(isError) return Promise.reject();
     return Promise.resolve();
   }
 
   read(isError: boolean): Promise<any> {
-    if(isError) return Promise.reject();
     return Promise.resolve();
   }
 
   update(isError: boolean): Promise<any> {
-    if(isError) return Promise.reject();
     return Promise.resolve();
   }
 
@@ -25,22 +22,18 @@ export class StorageServiceMock {
   }
 
   setItem(isError: boolean): Promise<any> {
-    if(isError) return Promise.reject();
     return Promise.resolve();
   }
 
   removeItem(isError: boolean): Promise<any> {
-    if(isError) return Promise.reject();
     return Promise.resolve();
   }
 
   delete(isError: boolean): Promise<any> {
-    if(isError) return Promise.reject();
     return Promise.resolve();
   }
 
   clearStorage(isError: boolean): Promise<any> {
-    if(isError) return Promise.reject();
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
(FE) As a VSA I want to know when a vehicle failed an annual test recently so that I know what test type to select (XL)

This ticket uses the new "suggested test types' that have been added to certain test types. When a certain type of vehicle fails a particular type of test within the last 20 days, a new alert will be shown when adding a new test type to display these suggested test types, the user can then pick one or view the vehicle's test history, or add a test type as normal.

PLEASE NOTE THAT THIS TICKET SHOULD BE IMPLEMENTED AFTER (OR IN SAME RELEASE AS) THE BACK-END TICKET 19434

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number