### PR TITLE
feat/cvsb 11706 (FE) As a VSA I want to know when a vehicle failed an annual test recently so that I know what test type to select (XL)

### DIFF
--- a/src/app/app.enums.ts
+++ b/src/app/app.enums.ts
@@ -259,9 +259,9 @@ export enum APP_STRINGS {
   SKELETON_ALERT_MESSAGE = 'This vehicle does not have enough data to be tested. Call Technical Support to correct this record and use SAR to test this vehicle.',
   SKELETON_INFO = 'Requires more data to be tested',
   SKELETON_BANNER = 'Some vehicles matching this search do not have enough data to be tested. Call Technical Support to correct these records and use SAR to test this vehicle.',
-
   SITE_VISIT_CLOSED_TITLE = 'Site Visit is closed',
-  SITE_VISIT_CLOSED_MESSAGE = 'This Site Visit has been closed. Open a new Site Visit to continue testing.'
+  SITE_VISIT_CLOSED_MESSAGE = 'This Site Visit has been closed. Open a new Site Visit to continue testing.',
+  RECENTLY_FAILED_TEST_TITLE = 'Suggested test types'
 }
 
 export enum ODOMETER_METRIC {

--- a/src/assets/data-mocks/data-model/test-data-model.mock.ts
+++ b/src/assets/data-mocks/data-model/test-data-model.mock.ts
@@ -10,4 +10,162 @@ export class TestDataModelMock {
       vehicles: []
     };
   }
+
+  public static getTestTypes() {
+    const testTypes = [
+      {
+        "id": "1",
+        "linkedIds": ["38", "39"],
+        "suggestedTestTypeIds": ["1", "7", "10"],
+        "name": "Annual test",
+        "testTypeName": "Annual test",
+        "forVehicleType": ["psv"],
+        "forVehicleSize": ["small", "large"],
+        "forVehicleConfiguration": ["articulated", "rigid"],
+        "forVehicleAxles": null,
+        "forEuVehicleCategory": null,
+        "forVehicleClass": null,
+        "forVehicleSubclass": null,
+        "forVehicleWheels": null,
+        "testTypeClassification": "Annual With Certificate",
+        "testCodes": [
+          {
+            "forVehicleType": "psv",
+            "forVehicleSize": "large",
+            "forVehicleConfiguration": "rigid",
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "defaultTestCode": "aal",
+            "linkedTestCode": null
+          },
+          {
+            "forVehicleType": "psv",
+            "forVehicleSize": "small",
+            "forVehicleConfiguration": "rigid",
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "defaultTestCode": "aas",
+            "linkedTestCode": null
+          },
+          {
+            "forVehicleType": "psv",
+            "forVehicleSize": "large",
+            "forVehicleConfiguration": "articulated",
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "defaultTestCode": "adl",
+            "linkedTestCode": null
+          }
+        ]
+      },
+      {
+        "id": "2",
+        "linkedIds": ["38", "39"],
+        "suggestedTestTypeIds": ["3", "4", "8"],
+        "name": "Class 6A",
+        "forVehicleType": ["psv"],
+        "forVehicleSize": ["small", "large"],
+        "forVehicleConfiguration": ["articulated", "rigid"],
+        "forVehicleAxles": null,
+        "forEuVehicleCategory": null,
+        "forVehicleClass": null,
+        "forVehicleSubclass": null,
+        "forVehicleWheels": null,
+        "nextTestTypesOrCategories": [
+          {
+            "id": "3",
+            "linkedIds": ["38", "39"],
+            "name": "Annual test",
+            "testTypeName": "Class 6A seatbelt installation check (annual test)",
+            "forVehicleType": ["psv"],
+            "forVehicleSize": ["small", "large"],
+            "forVehicleConfiguration": ["articulated", "rigid"],
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "testTypeClassification": "Annual With Certificate",
+            "testCodes": [
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": "large",
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "wdl",
+                "linkedTestCode": null
+              },
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": "small",
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "wds",
+                "linkedTestCode": null
+              }
+            ]
+          },
+          {
+            "id": "4",
+            "linkedIds": ["38", "39"],
+            "name": "First test",
+            "testTypeName": "Class 6A seatbelt installation check (first test)",
+            "forVehicleType": ["psv"],
+            "forVehicleSize": ["small", "large"],
+            "forVehicleConfiguration": ["articulated", "rigid"],
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "testTypeClassification": "Annual With Certificate",
+            "testCodes": [
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": "large",
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "wbl",
+                "linkedTestCode": null
+              },
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": "small",
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "wbs",
+                "linkedTestCode": null
+              }
+            ]
+          }
+        ]
+      }
+    ];
+    return testTypes;
+  }
 }

--- a/src/assets/data-mocks/reference-data-mocks/test-types.mock.ts
+++ b/src/assets/data-mocks/reference-data-mocks/test-types.mock.ts
@@ -6,6 +6,7 @@ export class TestTypesReferenceDataMock {
       {
         id: '1',
         sortId: '1',
+        suggestedTestTypeIds: ["1", "2", "4"],
         name: 'annual test',
         testTypeName: 'Annual test',
         forVehicleType: ['psv'],

--- a/src/models/reference-data-models/test-types.model.ts
+++ b/src/models/reference-data-models/test-types.model.ts
@@ -20,5 +20,8 @@ export interface TestTypesReferenceDataModel {
   forVehicleSubclass: string[] | string;
   forVehicleWheels: number[] | null;
   nextTestTypesOrCategories?: TestTypesReferenceDataModel[];
+  suggestedTestTypeDisplayName?: string;
+  suggestedTestTypeDisplayOrder?: number;
   linkedIds?: string[] | null;
+  suggestedTestTypeIds?: string[] | null;
 }

--- a/src/pages/testing/test-creation/test-create/test-create.html
+++ b/src/pages/testing/test-creation/test-create/test-create.html
@@ -184,7 +184,7 @@
         class="btn-add-test"
         ion-item
         detail-none
-        (click)="addVehicleTest(vehicle)"
+        (click)="onAddNewTestType(vehicle)"
         [ngClass]="{'bottom-divider': vehicle.testTypes.length == 0}"
       >
         <span *ngIf="vehicle.testTypes.length == 0">Add a test type</span>

--- a/src/pages/testing/test-creation/test-create/test-create.ts
+++ b/src/pages/testing/test-creation/test-create/test-create.ts
@@ -16,25 +16,26 @@ import { VisitService } from '../../../../providers/visit/visit.service';
 import { TestTypeModel } from '../../../../models/tests/test-type.model';
 import {
   ANALYTICS_EVENT_CATEGORIES,
-  ANALYTICS_EVENTS,
-  ANALYTICS_LABEL,
+  ANALYTICS_EVENTS, ANALYTICS_LABEL,
   ANALYTICS_SCREEN_NAMES,
   ANALYTICS_VALUE,
   APP,
   APP_STRINGS,
   DURATION_TYPE,
-  PAGE_NAMES,
-  TEST_COMPLETION_STATUS,
+  PAGE_NAMES, STORAGE,
+  TEST_COMPLETION_STATUS, TEST_REPORT_STATUSES,
   TEST_TYPE_INPUTS,
   TEST_TYPE_RESULTS,
   VEHICLE_TYPE
 } from '../../../../app/app.enums';
+import { StorageService } from '../../../../providers/natives/storage.service';
 import { TestTypesFieldsMetadata } from '../../../../assets/app-data/test-types-data/test-types-fields.metadata';
 import { CommonFunctionsService } from '../../../../providers/utils/common-functions';
 import { CallNumber } from '@ionic-native/call-number';
-import { AppService, AnalyticsService, DurationService } from '../../../../providers/global';
+import { AppService, AnalyticsService, DurationService, AppAlertService } from '../../../../providers/global';
 import { TestTypeService } from '../../../../providers/test-type/test-type.service';
 import { EuVehicleCategoryData } from '../../../../assets/app-data/eu-vehicle-category/eu-vehicle-category';
+import { TestTypesReferenceDataModel } from '../../../../models/reference-data-models/test-types.model';
 
 @IonicPage()
 @Component({
@@ -55,8 +56,9 @@ export class TestCreatePage implements OnInit {
   allVehiclesCompletelyTested: boolean = false;
   TEST_CREATE_ERROR_BANNER: typeof APP_STRINGS.TEST_CREATE_ERROR_BANNER =
     APP_STRINGS.TEST_CREATE_ERROR_BANNER;
+  testTypeReferenceData: TestTypesReferenceDataModel[];
 
-  constructor(
+constructor(
     public navCtrl: NavController,
     public navParams: NavParams,
     public callNumber: CallNumber,
@@ -70,7 +72,9 @@ export class TestCreatePage implements OnInit {
     private modalCtrl: ModalController,
     private analyticsService: AnalyticsService,
     private durationService: DurationService,
-    private testTypeService: TestTypeService
+    private testTypeService: TestTypeService,
+    private storageService: StorageService,
+    private alertService: AppAlertService,
   ) {
     this.testTypesFieldsMetadata = TestTypesFieldsMetadata.FieldsMetadata;
   }
@@ -82,6 +86,7 @@ export class TestCreatePage implements OnInit {
     this.testData = Object.keys(this.visitService.visit).length
       ? this.visitService.visit.tests[lastTestIndex]
       : this.navParams.get('test');
+    this.getTestTypeReferenceData();
   }
 
   ionViewWillEnter() {
@@ -305,13 +310,136 @@ export class TestCreatePage implements OnInit {
     return isInProgress ? 'In progress' : 'Edit';
   }
 
-  addVehicleTest(vehicle: VehicleModel): void {
+  getTestTypeReferenceData(): void {
+    this.testTypeService
+      .getTestTypesFromStorage()
+      .subscribe((data: TestTypesReferenceDataModel[]) => {
+        this.testTypeReferenceData = this.testTypeService.orderTestTypesArray(
+          data,
+          'id',
+          'asc'
+        );
+      });
+  }
+
+  getSuggestedTestTypes(testType: TestTypeModel) {
+    const flattenedTestTypes = this.testTypeService.flattenTestTypesData(this.testTypeReferenceData);
+    const suggestedTestTypeIds = this.testTypeService.getSuggestedTestTypeIds(testType.testTypeId, flattenedTestTypes);
+    const testTypes = this.testTypeService.determineAssociatedTestTypes(flattenedTestTypes, suggestedTestTypeIds);
+    return this.testTypeService.sortSuggestedTestTypes(testTypes);
+  }
+
+  async onAddNewTestType(vehicle: VehicleModel) {
     this.durationService.setDuration(
       { start: Date.now() },
       DURATION_TYPE[DURATION_TYPE.TEST_TYPE]
     );
 
+    let failedTest: null | TestTypeModel;
+    const testHistory = await this.storageService.read(STORAGE.TEST_HISTORY + vehicle.systemNumber);
+    if (testHistory.length) {
+      let testTypes: TestTypeModel[] = [];
+      let cutOffDate = new Date();
+      const DAYS_WITHIN_TEST_FAIL = 19;
+      cutOffDate.setDate(cutOffDate.getDate() - DAYS_WITHIN_TEST_FAIL);
+      cutOffDate.setHours(0,0,0,0);
+
+      testHistory.forEach(testResult => {
+        let testResultDate = new Date(testResult.testStartTimestamp);
+        testResultDate.setHours(0,0,0,0);
+
+        if (
+          testResult.testTypes.length &&
+          testResult.testStatus === TEST_REPORT_STATUSES.SUBMITTED &&
+          cutOffDate.valueOf() <= testResultDate.valueOf()
+        ) {
+          testResult.testTypes.forEach((testType) => {
+            if (this.getSuggestedTestTypes(testType).length) {
+              testTypes.push(testType);
+            }
+          });
+        }
+      });
+      if (testTypes.length) {
+        this.commonFunctions.orderTestTypeArrayByDate(testTypes);
+        for (let i = 0; i < testTypes.length; i++) {
+          if (testTypes[i].testResult === TEST_TYPE_RESULTS.FAIL) {
+            failedTest = testTypes[i];
+            break;
+          }
+        }
+      }
+    }
+    if (failedTest) {
+      this.handleRecentlyFailedTest(failedTest, vehicle);
+    } else {
+      this.addNewTestType(vehicle);
+    };
+  }
+
+  handleRecentlyFailedTest(failedTest: TestTypeModel, vehicle: VehicleModel) {
+    const suggestedTestTypes: TestTypesReferenceDataModel[] = this.getSuggestedTestTypes(failedTest);
+
+    let buttons = [];
+    for (let i = 0; i < suggestedTestTypes.length; i++) {
+      buttons.push({
+        text: suggestedTestTypes[i].suggestedTestTypeDisplayName,
+        handler: () => {
+          this.addSuggestedTestType(suggestedTestTypes[i], vehicle);
+        }
+      });
+    }
+
+    const failedTestDate = new Date(failedTest.testTypeStartTimestamp);
+    const RECENTLY_FAILED_TEST_MESSAGE = `This vehicle failed its ${failedTest.name.toLocaleLowerCase()} on `
+      + `${failedTestDate.toLocaleDateString('en-GB')}`.bold() + `<br><br> It may be eligible for retest if within `
+      + `14 working days.`.bold() + `<br><br> Check the ` + `date and failure items in test history`.bold()
+      + ` to correctly select one of the following test types.`;
+
+    this.alertService.alertSuggestedTestTypes(RECENTLY_FAILED_TEST_MESSAGE, vehicle, buttons, this);
+  }
+
+  async goToVehicleTestResultsHistory(vehicle: VehicleModel) {
+    const testResultsHistory = await this.storageService.read(
+      STORAGE.TEST_HISTORY + vehicle.systemNumber
+    );
+
+    await this.navCtrl.push(PAGE_NAMES.VEHICLE_HISTORY_PAGE, {
+      vehicleData: vehicle,
+      testResultsHistory: testResultsHistory ? testResultsHistory : []
+    });
+  }
+
+  addNewTestType(vehicle: VehicleModel) {
     this.navCtrl.push(PAGE_NAMES.TEST_TYPES_LIST_PAGE, { vehicleData: vehicle });
+  }
+
+  addSuggestedTestType(testType: TestTypesReferenceDataModel, vehicle: VehicleModel) {
+    const type = DURATION_TYPE[DURATION_TYPE.TEST_TYPE];
+    this.durationService.completeDuration(type, this);
+
+    if (testType.name.includes('retest')) {
+      testType.name = 'Retest';
+    }
+    let test = this.testTypeService.createTestType(
+      testType,
+      vehicle.techRecord.vehicleType
+    );
+    test.testTypeCategoryName = testType.name;
+    this.vehicleService.addTestType(vehicle, test);
+  }
+
+  async trackAddTestTypeDuration(label: string, value: string) {
+    await this.analyticsService.logEvent({
+      category: ANALYTICS_EVENT_CATEGORIES.TEST_TYPES,
+      event: ANALYTICS_EVENTS.ADD_TEST_TYPE_TIME_TAKEN,
+      label: ANALYTICS_LABEL[label]
+    });
+
+    await this.analyticsService.addCustomDimension(
+      Object.keys(ANALYTICS_LABEL).indexOf(label) + 1,
+      value
+    );
   }
 
   onVehicleDetails(vehicle: VehicleModel) {

--- a/src/pages/testing/test-creation/test-types-list/test-types-list.ts
+++ b/src/pages/testing/test-creation/test-types-list/test-types-list.ts
@@ -46,17 +46,14 @@ export class TestTypesListPage implements OnInit {
   }
 
   ngOnInit() {
-    if (this.testTypeReferenceData) {
+    if (this.testTypeReferenceData)
       this.testTypeReferenceData = this.testTypeService.orderTestTypesArray(
         this.testTypeReferenceData,
-        'sortId',
+        'id',
         'asc'
       );
-    } else {
-      this.getTestTypeRefByStorage();
-    }
-
     this.backBtn = this.navParams.get('backBtn');
+    this.getTestTypeReferenceData();
     let previousView = this.navCtrl.getPrevious();
     this.firstPage = previousView.id != PAGE_NAMES.TEST_TYPES_LIST_PAGE;
   }
@@ -70,16 +67,18 @@ export class TestTypesListPage implements OnInit {
     }
   }
 
-  getTestTypeRefByStorage(): void {
-    this.testTypeService
-      .getTestTypesFromStorage()
-      .subscribe((data: TestTypesReferenceDataModel[]) => {
-        this.testTypeReferenceData = this.testTypeService.orderTestTypesArray(
-          data,
-          'sortId',
-          'asc'
-        );
-      });
+  getTestTypeReferenceData(): void {
+    if (!this.testTypeReferenceData) {
+      this.testTypeService
+        .getTestTypesFromStorage()
+        .subscribe((data: TestTypesReferenceDataModel[]) => {
+          this.testTypeReferenceData = this.testTypeService.orderTestTypesArray(
+            data,
+            'id',
+            'asc'
+          );
+        });
+    } 
   }
 
   selectedItem(testType: TestTypesReferenceDataModel, vehicleData: VehicleModel): void {
@@ -95,13 +94,7 @@ export class TestTypesListPage implements OnInit {
       });
     } else {
       const type: string = DURATION_TYPE[DURATION_TYPE.TEST_TYPE];
-      this.durationService.setDuration({ end: Date.now() }, type);
-      const duration = this.durationService.getDuration(type);
-      const takenDuration = this.durationService.getTakenDuration(duration);
-
-      this.trackAddTestTypeDuration('ADD_TEST_TYPE_START_TIME', duration.start.toString());
-      this.trackAddTestTypeDuration('ADD_TEST_TYPE_END_TIME', duration.end.toString());
-      this.trackAddTestTypeDuration('ADD_TEST_TYPE_TIME_TAKEN', takenDuration.toString());
+      this.durationService.completeDuration(type, this);
 
       let views = this.navCtrl.getViews();
       for (let i = views.length - 1; i >= 0; i--) {

--- a/src/providers/global/app-alert.service.ts
+++ b/src/providers/global/app-alert.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
 import { CallNumber } from '@ionic-native/call-number';
 import { AlertController } from 'ionic-angular';
 
 import { default as AppConfig } from '../../../config/application.hybrid';
 import { APP_STRINGS, AUTH } from '../../app/app.enums';
+import { VehicleModel } from '../../models/vehicle/vehicle.model';
+import { TestCreatePage } from '../../pages/testing/test-creation/test-create/test-create';
 
 @Injectable()
 export class AppAlertService {
@@ -46,6 +48,35 @@ export class AppAlertService {
       title: AUTH.FAILED,
       message: APP_STRINGS.PLUGIN_FAILURE,
       buttons: [APP_STRINGS.OK]
+    });
+
+    alert.present();
+  }
+
+  alertSuggestedTestTypes(
+    message: string,
+    vehicle: VehicleModel,
+    buttons: any[],
+    testCreatePage: TestCreatePage
+  ) {
+    const alert = this.alertCtrl.create({
+      title: APP_STRINGS.RECENTLY_FAILED_TEST_TITLE,
+      message: message,
+      buttons: [...buttons,
+        {
+          text: 'Test History',
+          handler: () => {
+            testCreatePage.goToVehicleTestResultsHistory(vehicle);
+          }
+        },
+        {
+          text: 'Select a different test type',
+          handler: () => {
+            testCreatePage.addNewTestType(vehicle);
+          }
+        }
+      ],
+      enableBackdropDismiss: false,
     });
 
     alert.present();

--- a/src/providers/global/duration.service.ts
+++ b/src/providers/global/duration.service.ts
@@ -34,4 +34,13 @@ export class DurationService {
     const { start, end } = params;
     return Math.round((end - start) / 1000);
   }
+
+  completeDuration(type: string, currentPage) {
+    this.setDuration({ end: Date.now() }, type);
+    const duration = this.getDuration(type);
+    const takenDuration = this.getTakenDuration(duration);
+    currentPage.trackAddTestTypeDuration('ADD_TEST_TYPE_START_TIME', duration.start.toString());
+    currentPage.trackAddTestTypeDuration('ADD_TEST_TYPE_END_TIME', duration.end.toString());
+    currentPage.trackAddTestTypeDuration('ADD_TEST_TYPE_TIME_TAKEN', takenDuration.toString());
+  }
 }

--- a/src/providers/test-type/test-type.service.ts
+++ b/src/providers/test-type/test-type.service.ts
@@ -269,4 +269,30 @@ export class TestTypeService {
       ) !== -1
     );
   }
+
+  // Retrieve all nested Test Types and flatten into single array
+  flattenTestTypesData(array: TestTypesReferenceDataModel[]): TestTypesReferenceDataModel[] {
+    return array.reduce((innerArr, { nextTestTypesOrCategories, ...rest }) => {
+      if (nextTestTypesOrCategories) {
+        innerArr.push(...this.flattenTestTypesData(nextTestTypesOrCategories));
+      }
+      innerArr.push(rest);
+      return innerArr;
+    }, [])
+  }
+
+  getSuggestedTestTypeIds(id: string, flattenedTestTypes: TestTypesReferenceDataModel[]) {
+    const result = flattenedTestTypes.find((testType) => testType.id === id);
+    return result.suggestedTestTypeIds || [];
+  };
+
+  sortSuggestedTestTypes(suggestedTestTypes: TestTypesReferenceDataModel[]): TestTypesReferenceDataModel[] {
+    return suggestedTestTypes.sort(
+      function(a, b){ return a.suggestedTestTypeDisplayOrder - b.suggestedTestTypeDisplayOrder }
+    );
+  }
+
+  determineAssociatedTestTypes(flattenedTestTypes: TestTypesReferenceDataModel[], suggested: string[]): TestTypesReferenceDataModel[] {
+    return flattenedTestTypes.filter((testType) => suggested.includes(testType.id));
+  }
 }

--- a/src/providers/visit/visit.service.spec.ts
+++ b/src/providers/visit/visit.service.spec.ts
@@ -179,6 +179,7 @@ describe('Provider: VisitService', () => {
     expect(httpService.startVisit).toHaveBeenCalledTimes(1);
     expect(httpServiceSpy.startVisit.calls.mostRecent().args[0].testerEmail).toBe(emailExample);
   });
+  
 
   it('should update the storage', () => {
     visitService.updateVisit();


### PR DESCRIPTION
(FE) As a VSA I want to know when a vehicle failed an annual test recently so that I know what test type to select (XL)

This ticket uses the new "suggested test types' that have been added to certain test types. When a certain type of vehicle fails a particular type of test within the last 20 days, a new alert will be shown when adding a new test type to display these suggested test types, the user can then pick one or view the vehicle's test history, or add a test type as normal.

PLEASE NOTE THAT THIS TICKET SHOULD BE IMPLEMENTED AFTER (OR IN SAME RELEASE AS) THE BACK-END TICKET 19434

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number