### PR TITLE
feat(VTA-411): Fix uncaught error (invalid dates for date pipes) identified in sentry

### DIFF
--- a/src/pages/testing/test-creation/test-review/test-review.ts
+++ b/src/pages/testing/test-creation/test-review/test-review.ts
@@ -104,6 +104,9 @@ export class TestReviewPage implements OnInit {
 
     this.vehicleBeingReviewed = this.navParams.get('vehicleBeingReviewed') || 0;
     this.vehicle = this.latestTest.vehicles[this.vehicleBeingReviewed];
+    this.vehicle.testTypes.forEach(testType => {
+      this.testTypeService.fixDateFormatting(testType);
+    })
   }
 
   ngOnInit(): void {

--- a/src/pages/testing/test-creation/test-review/test-review.ts
+++ b/src/pages/testing/test-creation/test-review/test-review.ts
@@ -16,7 +16,6 @@ import {
   ANALYTICS_SCREEN_NAMES,
   ANALYTICS_EVENTS,
   ANALYTICS_EVENT_CATEGORIES,
-  ANALYTICS_LABEL,
   ANALYTICS_VALUE,
   APP_STRINGS,
   DATE_FORMAT,
@@ -106,7 +105,7 @@ export class TestReviewPage implements OnInit {
     this.vehicle = this.latestTest.vehicles[this.vehicleBeingReviewed];
     this.vehicle.testTypes.forEach(testType => {
       this.testTypeService.fixDateFormatting(testType);
-    })
+    });
   }
 
   ngOnInit(): void {

--- a/src/pages/testing/vehicle/vehicle-history-details/vehicle-history-details.spec.ts
+++ b/src/pages/testing/vehicle/vehicle-history-details/vehicle-history-details.spec.ts
@@ -11,7 +11,6 @@ import { TestResultsHistoryDataMock } from '../../../../assets/data-mocks/test-r
 import { AppService } from '../../../../providers/global/app.service';
 import { AppServiceMock } from '../../../../../test-config/services-mocks/app-service.mock';
 import { TestTypeService } from '../../../../providers/test-type/test-type.service';
-import { TestTypeServiceMock } from '../../../../../test-config/services-mocks/test-type-service.mock';
 import { ANALYTICS_SCREEN_NAMES, DEFICIENCY_CATEGORY } from '../../../../app/app.enums';
 import { DefectDetailsModel } from '../../../../models/defects/defect-details.model';
 import { MOCK_UTILS } from '../../../../../test-config/mocks/mocks.utils';

--- a/src/pages/testing/vehicle/vehicle-history-details/vehicle-history-details.spec.ts
+++ b/src/pages/testing/vehicle/vehicle-history-details/vehicle-history-details.spec.ts
@@ -25,11 +25,18 @@ describe('Component: VehicleHistoryDetailsPage', () => {
   let viewCtrl: ViewController;
   let analyticsService: AnalyticsService;
   let analyticsServiceSpy: any;
+  let testTypeService: TestTypeService;
+  let testTypeServiceSpy: any;
 
   const defects: DefectDetailsModel[] = [MOCK_UTILS.mockDefectsDetails()];
 
   beforeEach(async(() => {
     analyticsServiceSpy = jasmine.createSpyObj('AnalyticsService', ['setCurrentPage']);
+    testTypeServiceSpy = jasmine.createSpyObj('TestTypeService', [
+      'fixDateFormatting',
+      'isSpecialistWithoutCertificateNumberCapturedIds',
+      'isSpecialistCoifWithAnnualTest'
+    ]);
 
     TestBed.configureTestingModule({
       declarations: [VehicleHistoryDetailsPage],
@@ -39,7 +46,7 @@ describe('Component: VehicleHistoryDetailsPage', () => {
         CommonFunctionsService,
         { provide: NavParams, useClass: NavParamsMock },
         { provide: ViewController, useClass: ViewControllerMock },
-        { provide: TestTypeService, useClass: TestTypeServiceMock },
+        { provide: TestTypeService, useValue: testTypeServiceSpy },
         { provide: AnalyticsService, useValue: analyticsServiceSpy },
         { provide: AppService, useClass: AppServiceMock }
       ],
@@ -54,6 +61,7 @@ describe('Component: VehicleHistoryDetailsPage', () => {
     viewCtrl = TestBed.get(ViewController);
     commonFunctionsService = TestBed.get(CommonFunctionsService);
     analyticsService = TestBed.get(AnalyticsService);
+    testTypeService = TestBed.get(TestTypeService);
     comp.testIndex = 0;
     comp.testTypeIndex = 0;
     comp.testResultHistory = TestResultsHistoryDataMock.TestResultHistoryData;

--- a/src/pages/testing/vehicle/vehicle-history-details/vehicle-history-details.ts
+++ b/src/pages/testing/vehicle/vehicle-history-details/vehicle-history-details.ts
@@ -70,6 +70,7 @@ export class VehicleHistoryDetailsPage {
     this.defaultValues = DEFAULT_VALUES;
     this.doDefectsExist = this.checkForDefects(this.selectedTestType.defects);
 
+    this.testTypeService.fixDateFormatting(this.selectedTestType);
     this.setTestMetadata();
     this.compareTestWithMetadata();
 

--- a/src/pages/testing/vehicle/vehicle-history/vehicle-history.module.ts
+++ b/src/pages/testing/vehicle/vehicle-history/vehicle-history.module.ts
@@ -3,10 +3,11 @@ import { IonicPageModule } from 'ionic-angular';
 import { VehicleHistoryPage } from './vehicle-history';
 import { CommonFunctionsService } from '../../../../providers/utils/common-functions';
 import { PipesModule } from '../../../../pipes/pipes.module';
+import { TestTypeService } from '../../../../providers/test-type/test-type.service';
 
 @NgModule({
   declarations: [VehicleHistoryPage],
   imports: [IonicPageModule.forChild(VehicleHistoryPage), PipesModule],
-  providers: [CommonFunctionsService]
+  providers: [CommonFunctionsService, TestTypeService]
 })
 export class VehicleHistoryPageModule {}

--- a/src/pages/testing/vehicle/vehicle-history/vehicle-history.spec.ts
+++ b/src/pages/testing/vehicle/vehicle-history/vehicle-history.spec.ts
@@ -17,6 +17,7 @@ import {
 import { VehicleHistoryPage } from './vehicle-history';
 import { VehicleModel } from '../../../../models/vehicle/vehicle.model';
 import { AnalyticsService } from '../../../../providers/global';
+import { TestTypeService } from '../../../../providers/test-type/test-type.service';
 
 describe('Component: VehicleHistoryPage', () => {
   let comp: VehicleHistoryPage;
@@ -26,6 +27,8 @@ describe('Component: VehicleHistoryPage', () => {
   let commonFunctionsService: any;
   let analyticsService: AnalyticsService;
   let analyticsServiceSpy: any;
+  let testTypeService: TestTypeService;
+  let testTypeServiceSpy: any;
 
   let testResultsHistory: any = TestResultsHistoryDataMock.TestResultHistoryData;
   let vehicleData: VehicleModel = VehicleDataMock.VehicleData;
@@ -33,6 +36,7 @@ describe('Component: VehicleHistoryPage', () => {
 
   beforeEach(async(() => {
     analyticsServiceSpy = jasmine.createSpyObj('AnalyticsService', ['setCurrentPage']);
+    testTypeServiceSpy = jasmine.createSpyObj('TestTypeService', ['fixDateFormatting']);
 
     TestBed.configureTestingModule({
       declarations: [VehicleHistoryPage],
@@ -42,7 +46,8 @@ describe('Component: VehicleHistoryPage', () => {
         CommonFunctionsService,
         { provide: NavParams, useClass: NavParamsMock },
         { provide: ViewController, useClass: ViewControllerMock },
-        { provide: AnalyticsService, useValue: analyticsServiceSpy }
+        { provide: AnalyticsService, useValue: analyticsServiceSpy },
+        { provide: TestTypeService, useValue: testTypeServiceSpy }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });
@@ -52,6 +57,7 @@ describe('Component: VehicleHistoryPage', () => {
     navCtrl = TestBed.get(NavController);
     navParams = TestBed.get(NavParams);
     analyticsService = TestBed.get(AnalyticsService);
+    testTypeService = TestBed.get(TestTypeService);
     commonFunctionsService = TestBed.get(CommonFunctionsService);
 
     navParams.get = jasmine.createSpy('get').and.callFake((param) => {

--- a/src/pages/testing/vehicle/vehicle-history/vehicle-history.ts
+++ b/src/pages/testing/vehicle/vehicle-history/vehicle-history.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../../app/app.enums';
 import { TestResultModel } from '../../../../models/tests/test-result.model';
 import { AnalyticsService } from '../../../../providers/global';
+import { TestTypeService } from '../../../../providers/test-type/test-type.service';
 
 @IonicPage()
 @Component({
@@ -31,7 +32,8 @@ export class VehicleHistoryPage {
     public navParams: NavParams,
     public viewCtrl: ViewController,
     public commonFunc: CommonFunctionsService,
-    private analyticsService: AnalyticsService
+    private analyticsService: AnalyticsService,
+    public testTypeService: TestTypeService
   ) {
     this.vehicleData = navParams.get('vehicleData');
     this.testResultHistory = navParams.get('testResultsHistory');
@@ -71,6 +73,7 @@ export class VehicleHistoryPage {
           testResult.testTypes.forEach((testType, typeTypeIndex) => {
             testType.testIndex = testIndex;
             testType.testTypeIndex = typeTypeIndex;
+            this.testTypeService.fixDateFormatting(testType);
             this.testTypeArray.push(testType);
           });
         }

--- a/src/providers/test-type/test-type.service.ts
+++ b/src/providers/test-type/test-type.service.ts
@@ -273,10 +273,18 @@ export class TestTypeService {
   fixDateFormatting(testType: TestTypeModel) {
     testType.testTypeStartTimestamp =
       this.commonFunctions.fixDateFormat(testType.testTypeStartTimestamp);
-    testType.testTypeEndTimestamp =
-      this.commonFunctions.fixDateFormat(testType.testTypeEndTimestamp);
-    testType.testExpiryDate =
-      this.commonFunctions.fixDateFormat(testType.testExpiryDate);
+    if (testType.testTypeEndTimestamp) {
+      testType.testTypeEndTimestamp =
+        this.commonFunctions.fixDateFormat(testType.testTypeEndTimestamp);
+    }
+    if (testType.testExpiryDate) {
+      testType.testExpiryDate =
+        this.commonFunctions.fixDateFormat(testType.testExpiryDate);
+    }
+    if (testType.lastSeatbeltInstallationCheckDate) {
+      testType.lastSeatbeltInstallationCheckDate =
+        this.commonFunctions.fixDateFormat(testType.lastSeatbeltInstallationCheckDate);
+    }
   }
 
   // Retrieve all nested Test Types and flatten into single array

--- a/src/providers/test-type/test-type.service.ts
+++ b/src/providers/test-type/test-type.service.ts
@@ -270,6 +270,15 @@ export class TestTypeService {
     );
   }
 
+  fixDateFormatting(testType: TestTypeModel) {
+    testType.testTypeStartTimestamp =
+      this.commonFunctions.fixDateFormat(testType.testTypeStartTimestamp);
+    testType.testTypeEndTimestamp =
+      this.commonFunctions.fixDateFormat(testType.testTypeEndTimestamp);
+    testType.testExpiryDate =
+      this.commonFunctions.fixDateFormat(testType.testExpiryDate);
+  }
+
   // Retrieve all nested Test Types and flatten into single array
   flattenTestTypesData(array: TestTypesReferenceDataModel[]): TestTypesReferenceDataModel[] {
     return array.reduce((innerArr, { nextTestTypesOrCategories, ...rest }) => {

--- a/src/providers/utils/common-functions.spec.ts
+++ b/src/providers/utils/common-functions.spec.ts
@@ -203,4 +203,10 @@ describe('Provider: CommonFunctionsService', () => {
       expect(result).toEqual('');
     });
   });
+
+  it('should check that dates incorrectly formatted are fixed', () => {
+    let badDate = '2020-02-14 00:00:00.000000';
+    let goodDate = commonFunctionsService.fixDateFormat(badDate);
+    expect(goodDate).toEqual('2020-02-14T00:00:00.000000Z');
+  })
 });

--- a/src/providers/utils/common-functions.ts
+++ b/src/providers/utils/common-functions.ts
@@ -173,7 +173,7 @@ export class CommonFunctionsService {
     return obfuscated;
   }
 
-  fixDateFormat(timestamp: string): string{
+  fixDateFormat(timestamp: string): string {
     if (timestamp && timestamp.includes(' ')) {
       const dateTime = timestamp.split(' ');
       return (dateTime[0] + 'T' + dateTime[1] + 'Z');

--- a/src/providers/utils/common-functions.ts
+++ b/src/providers/utils/common-functions.ts
@@ -173,6 +173,15 @@ export class CommonFunctionsService {
     return obfuscated;
   }
 
+  fixDateFormat(timestamp: string): string{
+    if (timestamp && timestamp.includes(' ')) {
+      const dateTime = timestamp.split(' ');
+      return (dateTime[0] + 'T' + dateTime[1] + 'Z');
+    } else {
+      return timestamp;
+    }
+  }
+
   millisecondsIntoMinutes(milliseconds: number): number {
     return milliseconds / 60000;
   }

--- a/test-config/services-mocks/test-type-service.mock.ts
+++ b/test-config/services-mocks/test-type-service.mock.ts
@@ -167,4 +167,8 @@ export class TestTypeServiceMock {
   isSpecialistWithoutCertificateNumberCapturedIds(testTypeId: string): boolean {
     return SpecialistTestTypesData.SpecialistWithoutCertificateNumberCapturedIds.indexOf(testTypeId) !== -1;
   }
+
+  fixDateFormatting(testType: TestTypeModel) {
+    // dates already fixed
+  }
 }


### PR DESCRIPTION
VTA-411 - Fix uncaught error (invalid dates for date pipes) identified in sentry
Added a function in common functions to fix the formatting of dates, called this function for test types being outputted in the vehicle-history and vehicle-history-details pages..
[link to ticket number](https://jira.dvsacloud.uk/browse/VTA-411)

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number