### PR TITLE
Feature/vta-153 - extra context to errors in sentry

### DIFF
--- a/src/app/sentry-ionic-errorhandler.ts
+++ b/src/app/sentry-ionic-errorhandler.ts
@@ -3,10 +3,11 @@ import { IonicErrorHandler } from 'ionic-angular';
 import * as Sentry from 'sentry-cordova';
 
 import { VaultService } from '../providers/auth';
+import { VisitService } from '../providers/visit/visit.service';
 
 @Injectable()
 export class SentryIonicErrorHandler extends IonicErrorHandler {
-  constructor(private vaultService: VaultService) {
+  constructor(private vaultService: VaultService, private visitService: VisitService) {
     super();
   }
 
@@ -14,10 +15,20 @@ export class SentryIonicErrorHandler extends IonicErrorHandler {
     super.handleError(error);
 
     const appUser = await this.vaultService.getTesterObsfuscatedId();
+    const testerName = this.visitService.getCurrentTesterName();
+    const atfName = this.visitService.getCurrentATF();
+    const atfPNumber = this.visitService.getCurrentATFPNumber();
+    const vin = this.visitService.getCurrentVIN();
+    const testTypeId = this.visitService.getCurrentTestTypeID();
 
     try {
       Sentry.withScope((scope) => {
         scope.setTag('app-user', appUser);
+        scope.setTag('tester-name', testerName);
+        scope.setTag('test-station', atfName);
+        scope.setTag('aft-p-number', atfPNumber);
+        scope.setTag('vehicle-vin', vin);
+        scope.setTag('test-type-id', testTypeId);
         Sentry.captureException(error.originalError || error);
       });
     } catch (e) {

--- a/src/providers/visit/visit.service.spec.ts
+++ b/src/providers/visit/visit.service.spec.ts
@@ -14,7 +14,9 @@ import { AppServiceMock } from '../../../test-config/services-mocks/app-service.
 import { ActivityService } from '../activity/activity.service';
 import { ActivityServiceMock } from '../../../test-config/services-mocks/activity-service.mock';
 import { AuthenticationServiceMock } from './../../../test-config/services-mocks/authentication-service.mock';
-
+import { VehicleModel } from '../../models/vehicle/vehicle.model';
+import { VehicleDataMock } from '../../assets/data-mocks/vehicle-data.mock';
+import { TestTypeModel } from '../../models/tests/test-type.model';
 describe('Provider: VisitService', () => {
   let visitService: VisitService;
   let appService: AppService;
@@ -27,6 +29,34 @@ describe('Provider: VisitService', () => {
 
   const TEST_STATION: TestStationReferenceDataModel = TestStationDataMock.TestStationData[0];
   let TEST: TestModel = TestDataModelMock.TestData;
+  let VEHICLE: VehicleModel = VehicleDataMock.VehicleData;
+  let aTest: TestModel = {
+    startTime: null,
+    endTime: '14 March',
+    status: null,
+    reasonForCancellation: '',
+    vehicles: [VEHICLE]
+  };
+  let aTestType: TestTypeModel = {
+    prohibitionIssued: false,
+    testNumber: '1',
+    additionalCommentsForAbandon: 'none',
+    numberOfSeatbeltsFitted: 2,
+    testTypeEndTimestamp: '2019-01-15T10:36:33.987Z',
+    reasonForAbandoning: 'none',
+    lastSeatbeltInstallationCheckDate: '2019-01-14',
+    testExpiryDate: '2020-02-21T08:47:59.749Z',
+    testTypeId: '1',
+    testTypeStartTimestamp: '2019-01-15T10:36:33.987Z',
+    certificateNumber: '1234',
+    secondaryCertificateNumber: null,
+    testTypeName: 'Annual test',
+    seatbeltInstallationCheckDate: true,
+    additionalNotesRecorded: 'VEHICLE FRONT REGISTRATION PLATE MISSING',
+    defects: [],
+    name: 'Annual test',
+    testResult: 'pass'
+  }
 
   beforeEach(() => {
     storageServiceSpy = jasmine.createSpyObj('StorageService', ['update', 'delete']);
@@ -106,13 +136,6 @@ describe('Provider: VisitService', () => {
 
   it('should return the latest test', () => {
     visitService.createVisit(TEST_STATION);
-    let aTest: TestModel = {
-      startTime: null,
-      endTime: '14 March',
-      status: null,
-      reasonForCancellation: '',
-      vehicles: []
-    };
     visitService.visit.tests.push(aTest);
     let lateTest = visitService.getLatestTest();
     expect(lateTest.endTime).toMatch('14 March');
@@ -196,5 +219,47 @@ describe('Provider: VisitService', () => {
       jasmine.createSpyObj('Loading', ['dismiss', 'present'])
     );
     expect(alert.onDidDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return the latest vehicle', () => {
+    visitService.createVisit(TEST_STATION);
+    visitService.visit.tests.push(aTest);
+    expect(visitService.getLatestVehicle().vrm).toMatch('BQ91YHQ');
+  });
+
+  it('should return the current ATF name', () => {
+    expect(visitService.getCurrentATF()).toMatch('N/A');
+    visitService.createVisit(TEST_STATION);
+    expect(visitService.getCurrentATF()).toMatch('An Test Station Name');
+  });
+
+  it('should return the current ATF P number', () => {
+    expect(visitService.getCurrentATFPNumber()).toMatch('N/A');
+    visitService.createVisit(TEST_STATION);
+    expect(visitService.getCurrentATFPNumber()).toMatch('123');
+  });
+
+  it('should return the current VIN', () => {
+    expect(visitService.getCurrentVIN()).toMatch('N/A');
+    visitService.createVisit(TEST_STATION);
+    visitService.visit.tests.push(aTest);
+    expect(visitService.getCurrentVIN()).toMatch('1B7GG36N12S678410');
+  });
+
+  it('should return the current test type ID', () => {
+    expect(visitService.getCurrentTestTypeID()).toMatch('N/A');
+    visitService.createVisit(TEST_STATION);
+    visitService.visit.tests.push(aTest);
+    expect(visitService.getCurrentTestTypeID()).toMatch('N/A');
+    visitService.visit.tests.pop();
+    aTest.vehicles[0].testTypes.push(aTestType);
+    visitService.visit.tests.push(aTest);
+    expect(visitService.getCurrentTestTypeID()).toMatch('1');
+  });
+
+  it('should return the name of the current tester', () => {
+    expect(visitService.getCurrentTesterName()).toMatch('N/A');
+    visitService.visit.testerName = 'some guy';
+    expect(visitService.getCurrentTesterName()).toMatch('some guy');
   });
 });

--- a/src/providers/visit/visit.service.ts
+++ b/src/providers/visit/visit.service.ts
@@ -10,6 +10,8 @@ import { Observable } from 'rxjs';
 import { AuthenticationService } from '../auth/authentication/authentication.service';
 import { AppService } from '../global/app.service';
 import { ActivityService } from '../activity/activity.service';
+import { VehicleModel } from '../../models/vehicle/vehicle.model';
+import { TestTypeModel } from '../../models/tests/test-type.model';
 
 @Injectable()
 export class VisitService {
@@ -64,7 +66,9 @@ export class VisitService {
   }
 
   getLatestTest(): TestModel {
-    return this.visit.tests[this.visit.tests.length - 1];
+    if (this.visit.tests) {
+      return this.visit.tests[this.visit.tests.length - 1];
+    }
   }
 
   addTest(test: TestModel) {
@@ -137,5 +141,48 @@ export class VisitService {
     this.visit = {} as VisitModel;
     this.activityService.activities = [];
     clearTimeout(this.activityService.waitTimer);
+  }
+
+  getLatestVehicle(): VehicleModel {
+    if (this.getLatestTest()) {
+      return this.getLatestTest().vehicles[this.getLatestTest().vehicles.length -1];
+    }
+  }
+
+  getLatestTestType(): TestTypeModel {
+    if (this.getLatestVehicle()){
+      return this.getLatestVehicle().testTypes[this.getLatestVehicle().testTypes.length -1];
+    }
+  }
+
+  getCurrentATF(): string {
+    return this.visit.testStationName ? this.visit.testStationName : 'N/A';
+  }
+
+  getCurrentATFPNumber(): string {
+    return this.visit.testStationPNumber ? this.visit.testStationPNumber : 'N/A';
+  }
+
+  getCurrentVIN(): string {
+    const test = this.getLatestTest();
+    let vehicle;
+    if (test) {
+      vehicle = this.getLatestVehicle();
+    }
+    return vehicle && !test.status ? vehicle.vin : 'N/A';
+  }
+
+  getCurrentTestTypeID(): string {
+    const test = this.getLatestTest();
+    const vehicle = this.getLatestVehicle();
+    let testType;
+    if (test && vehicle) {
+      testType = this.getLatestTestType();
+    }
+    return testType && !test.status ? testType.testTypeId : 'N/A';
+  }
+
+  getCurrentTesterName(): string {
+    return this.visit.testerName? this.visit.testerName : 'N/A';
   }
 }


### PR DESCRIPTION
Record contextual Info on Sentry Errors
Added extra context to errors in sentry
[link to ticket number](https://jira.dvsacloud.uk/browse/VTA-153)

Example exception: https://sentry.io/organizations/driver-and-vehicle-standards-a/issues/2703049161/?environment=develop&project=5419777&query=is%3Aunresolved

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/86603181/151537968-db0a68ae-b36b-4889-9ccd-dadb60c0d929.png">


## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number