### PR TITLE
fix(vtm-dev-1): Cannot amend Tech Record with frontVehicleTo5thWheelCouplingMax or Min

### DIFF
--- a/src/models/vehicle/tech-record.model.ts
+++ b/src/models/vehicle/tech-record.model.ts
@@ -64,8 +64,8 @@ export interface TechRecordModel {
   euroStandard?: number;
   frontAxleTo5thWheelMin?: number;
   frontAxleTo5thWheelMax?: number;
-  frontAxleTo5thWheelCouplingMin?: number;
-  frontAxleTo5thWheelCouplingMax?: number;
+  frontVehicleTo5thWheelCouplingMin?: number;
+  frontVehicleTo5thWheelCouplingMax?: number;
   /* -------- ONLY FOR TRL -------- */
   firstUseDate?: string;
   maxLoadOnCoupling?: number;

--- a/src/pages/testing/vehicle/vehicle-additional/vehicle-additional.html
+++ b/src/pages/testing/vehicle/vehicle-additional/vehicle-additional.html
@@ -263,7 +263,7 @@
         <h3>Min</h3>
       </ion-label>
       <div item-content padding-right>
-        <p>{{ vehicleData.techRecord.frontAxleTo5thWheelCouplingMin }}</p>
+        <p>{{ vehicleData.techRecord.frontVehicleTo5thWheelCouplingMin }}</p>
       </div>
     </ion-item>
 
@@ -272,7 +272,7 @@
         <h3>Max</h3>
       </ion-label>
       <div item-content padding-right>
-        <p>{{ vehicleData.techRecord.frontAxleTo5thWheelCouplingMax }}</p>
+        <p>{{ vehicleData.techRecord.frontVehicleTo5thWheelCouplingMax }}</p>
       </div>
     </ion-item>
   </ion-list>


### PR DESCRIPTION
Cannot amend Tech Record with frontVehicleTo5thWheelCouplingMax or Min

Global find and replace of AxleTo5thWheelCoupling -> VehicleTo5thWheelCoupling

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-7666)

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number